### PR TITLE
Reflection token reinvest contract

### DIFF
--- a/contracts/interfaces/IPair.sol
+++ b/contracts/interfaces/IPair.sol
@@ -9,4 +9,5 @@ interface IPair is IERC20 {
     function swap(uint amount0Out, uint amount1Out, address to, bytes calldata data) external;
     function getReserves() external view returns (uint112 reserve0, uint112 reserve1, uint32 blockTimestampLast);
     function mint(address to) external returns (uint liquidity);
+    function sync() external;
 }

--- a/flatten/DexStrategyV5Reflection.sol
+++ b/flatten/DexStrategyV5Reflection.sol
@@ -1,0 +1,1195 @@
+// Sources flattened with hardhat v2.3.0 https://hardhat.org
+
+// File contracts/lib/SafeMath.sol
+
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.7.0;
+
+// From https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/math/Math.sol
+// Subject to the MIT license.
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow
+ * checks.
+ *
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+ * in bugs, because programmers usually assume that an overflow raises an
+ * error, which is the standard behavior in high level programming languages.
+ * `SafeMath` restores this intuition by reverting the transaction when an
+ * operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ */
+library SafeMath {
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting on overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     * - Addition cannot overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, "SafeMath: addition overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the addition of two unsigned integers, reverting with custom message on overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     * - Addition cannot overflow.
+     */
+    function add(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a, errorMessage);
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting on underflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     * - Subtraction cannot underflow.
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        return sub(a, b, "SafeMath: subtraction underflow");
+    }
+
+    /**
+     * @dev Returns the subtraction of two unsigned integers, reverting with custom message on underflow (when the result is negative).
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     * - Subtraction cannot underflow.
+     */
+    function sub(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b <= a, errorMessage);
+        uint256 c = a - b;
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     * - Multiplication cannot overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, "SafeMath: multiplication overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the multiplication of two unsigned integers, reverting on overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     * - Multiplication cannot overflow.
+     */
+    function mul(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b, errorMessage);
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers.
+     * Reverts on division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b) internal pure returns (uint256) {
+        return div(a, b, "SafeMath: division by zero");
+    }
+
+    /**
+     * @dev Returns the integer division of two unsigned integers.
+     * Reverts with custom message on division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator. Note: this function uses a
+     * `revert` opcode (which leaves remaining gas untouched) while Solidity
+     * uses an invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     * - The divisor cannot be zero.
+     */
+    function div(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        // Solidity only automatically asserts when dividing by 0
+        require(b > 0, errorMessage);
+        uint256 c = a / b;
+        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b) internal pure returns (uint256) {
+        return mod(a, b, "SafeMath: modulo by zero");
+    }
+
+    /**
+     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+     * Reverts with custom message when dividing by zero.
+     *
+     * Counterpart to Solidity's `%` operator. This function uses a `revert`
+     * opcode (which leaves remaining gas untouched) while Solidity uses an
+     * invalid opcode to revert (consuming all remaining gas).
+     *
+     * Requirements:
+     * - The divisor cannot be zero.
+     */
+    function mod(uint256 a, uint256 b, string memory errorMessage) internal pure returns (uint256) {
+        require(b != 0, errorMessage);
+        return a % b;
+    }
+}
+
+
+// File contracts/lib/Context.sol
+
+
+/*
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with GSN meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract Context {
+    function _msgSender() internal view virtual returns (address payable) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes memory) {
+        this; // silence state mutability warning without generating bytecode - see https://github.com/ethereum/solidity/issues/2691
+        return msg.data;
+    }
+}
+
+
+// File contracts/lib/Ownable.sol
+
+/**
+ * @dev Contract module which provides a basic access control mechanism, where
+ * there is an account (an owner) that can be granted exclusive access to
+ * specific functions.
+ *
+ * By default, the owner account will be the one that deploys the contract. This
+ * can later be changed with {transferOwnership}.
+ *
+ * This module is used through inheritance. It will make available the modifier
+ * `onlyOwner`, which can be applied to your functions to restrict their use to
+ * the owner.
+ */
+abstract contract Ownable is Context {
+    address private _owner;
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev Initializes the contract setting the deployer as the initial owner.
+     */
+    constructor () {
+        address msgSender = _msgSender();
+        _owner = msgSender;
+        emit OwnershipTransferred(address(0), msgSender);
+    }
+
+    /**
+     * @dev Returns the address of the current owner.
+     */
+    function owner() public view virtual returns (address) {
+        return _owner;
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(owner() == _msgSender(), "Ownable: caller is not the owner");
+        _;
+    }
+
+    /**
+     * @dev Leaves the contract without owner. It will not be possible to call
+     * `onlyOwner` functions anymore. Can only be called by the current owner.
+     *
+     * NOTE: Renouncing ownership will leave the contract without an owner,
+     * thereby removing any functionality that is only available to the owner.
+     */
+    function renounceOwnership() public virtual onlyOwner {
+        emit OwnershipTransferred(_owner, address(0));
+        _owner = address(0);
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     * Can only be called by the current owner.
+     */
+    function transferOwnership(address newOwner) public virtual onlyOwner {
+        require(newOwner != address(0), "Ownable: new owner is the zero address");
+        emit OwnershipTransferred(_owner, newOwner);
+        _owner = newOwner;
+    }
+}
+
+
+// File contracts/lib/Permissioned.sol
+
+
+abstract contract Permissioned is Ownable {
+    using SafeMath for uint;
+
+    uint public numberOfAllowedDepositors;
+    mapping(address => bool) public allowedDepositors;
+
+    event AllowDepositor(address indexed account);
+    event RemoveDepositor(address indexed account);
+
+    modifier onlyAllowedDeposits() {
+        if (numberOfAllowedDepositors > 0) {
+            require(allowedDepositors[msg.sender] == true, "Permissioned::onlyAllowedDeposits, not allowed");
+        }
+        _;
+    }
+
+    /**
+     * @notice Add an allowed depositor
+     * @param depositor address
+     */
+    function allowDepositor(address depositor) external onlyOwner {
+        require(allowedDepositors[depositor] == false, "Permissioned::allowDepositor");
+        allowedDepositors[depositor] = true;
+        numberOfAllowedDepositors = numberOfAllowedDepositors.add(1);
+        emit AllowDepositor(depositor);
+    }
+
+    /**
+     * @notice Remove an allowed depositor
+     * @param depositor address
+     */
+    function removeDepositor(address depositor) external onlyOwner {
+        require(numberOfAllowedDepositors > 0, "Permissioned::removeDepositor, no allowed depositors");
+        require(allowedDepositors[depositor] == true, "Permissioned::removeDepositor, not allowed");
+        allowedDepositors[depositor] = false;
+        numberOfAllowedDepositors = numberOfAllowedDepositors.sub(1);
+        emit RemoveDepositor(depositor);
+    }
+}
+
+
+// File contracts/interfaces/IERC20.sol
+
+interface IERC20 {
+    function name() external view returns (string memory);
+    function symbol() external view returns (string memory);
+    function decimals() external view returns (uint8);
+    function totalSupply() external view returns (uint256);
+    function balanceOf(address account) external view returns (uint256);
+    function transfer(address recipient, uint256 amount) external returns (bool);
+    function allowance(address owner, address spender) external view returns (uint256);
+    function approve(address spender, uint256 amount) external returns (bool);
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+    function permit(address owner, address spender, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) external;
+    event Transfer(address indexed from, address indexed to, uint256 value);
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+
+// File contracts/YakERC20.sol
+
+
+
+abstract contract YakERC20 {
+    using SafeMath for uint256;
+
+    string public name = "Yield Yak";
+    string public symbol = "YRT";
+    uint8 public constant decimals = 18;
+    uint256 public totalSupply;
+  
+    mapping (address => mapping (address => uint256)) internal allowances;
+    mapping (address => uint256) internal balances;
+
+    // kec256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)")
+    bytes32 public constant DOMAIN_TYPEHASH = 0x8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f;
+
+    // kec256("1");
+    bytes32 public constant VERSION_HASH = 0xc89efdaa54c0f20c7adf612882df0950f5a951637e0307cdcb4c672f298b8bc6;
+
+    // kec256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
+    bytes32 public constant PERMIT_TYPEHASH = 0x6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c9;
+
+    mapping(address => uint) public nonces;
+
+    event Transfer(address indexed from, address indexed to, uint256 value);
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+
+    constructor() {}
+
+    /**
+     * @notice Get the number of tokens `spender` is approved to spend on behalf of `account`
+     * @param account The address of the account holding the funds
+     * @param spender The address of the account spending the funds
+     * @return The number of tokens approved
+     */
+    function allowance(address account, address spender) external view returns (uint) {
+        return allowances[account][spender];
+    }
+
+    /**
+     * @notice Approve `spender` to transfer up to `amount` from `src`
+     * @dev This will overwrite the approval amount for `spender`
+     * and is subject to issues noted [here](https://eips.ethereum.org/EIPS/eip-20#approve)
+     * It is recommended to use increaseAllowance and decreaseAllowance instead
+     * @param spender The address of the account which may transfer tokens
+     * @param amount The number of tokens that are approved (2^256-1 means infinite)
+     * @return Whether or not the approval succeeded
+     */
+    function approve(address spender, uint256 amount) external returns (bool) {
+        _approve(msg.sender, spender, amount);
+        return true;
+    }
+
+    /**
+     * @notice Get the number of tokens held by the `account`
+     * @param account The address of the account to get the balance of
+     * @return The number of tokens held
+     */
+    function balanceOf(address account) external view returns (uint) {
+        return balances[account];
+    }
+
+    /**
+     * @notice Transfer `amount` tokens from `msg.sender` to `dst`
+     * @param dst The address of the destination account
+     * @param amount The number of tokens to transfer
+     * @return Whether or not the transfer succeeded
+     */
+    function transfer(address dst, uint256 amount) external returns (bool) {
+        _transferTokens(msg.sender, dst, amount);
+        return true;
+    }
+
+    /**
+     * @notice Transfer `amount` tokens from `src` to `dst`
+     * @param src The address of the source account
+     * @param dst The address of the destination account
+     * @param amount The number of tokens to transfer
+     * @return Whether or not the transfer succeeded
+     */
+    function transferFrom(address src, address dst, uint256 amount) external returns (bool) {
+        address spender = msg.sender;
+        uint256 spenderAllowance = allowances[src][spender];
+
+        if (spender != src && spenderAllowance != uint256(-1)) {
+            uint256 newAllowance = spenderAllowance.sub(amount, "transferFrom: transfer amount exceeds allowance");
+            allowances[src][spender] = newAllowance;
+
+            emit Approval(src, spender, newAllowance);
+        }
+
+        _transferTokens(src, dst, amount);
+        return true;
+    }
+
+
+    /**
+     * @notice Approval implementation
+     * @param owner The address of the account which owns tokens
+     * @param spender The address of the account which may transfer tokens
+     * @param amount The number of tokens that are approved (2^256-1 means infinite)
+     */
+    function _approve(address owner, address spender, uint256 amount) internal {
+        require(owner != address(0), "_approve::owner zero address");
+        require(spender != address(0), "_approve::spender zero address");
+        allowances[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
+    }
+
+    /**
+     * @notice Transfer implementation
+     * @param from The address of the account which owns tokens
+     * @param to The address of the account which is receiving tokens
+     * @param value The number of tokens that are being transferred
+     */
+    function _transferTokens(address from, address to, uint256 value) internal {
+        require(to != address(0), "_transferTokens: cannot transfer to the zero address");
+
+        balances[from] = balances[from].sub(value, "_transferTokens: transfer exceeds from balance");
+        balances[to] = balances[to].add(value);
+        emit Transfer(from, to, value);
+    }
+
+    function _mint(address to, uint256 value) internal {
+        totalSupply = totalSupply.add(value);
+        balances[to] = balances[to].add(value);
+        emit Transfer(address(0), to, value);
+    }
+
+    function _burn(address from, uint256 value) internal {
+        balances[from] = balances[from].sub(value, "_burn: burn amount exceeds from balance");
+        totalSupply = totalSupply.sub(value, "_burn: burn amount exceeds total supply");
+        emit Transfer(from, address(0), value);
+    }
+
+    /**
+     * @notice Triggers an approval from owner to spender
+     * @param owner The address to approve from
+     * @param spender The address to be approved
+     * @param value The number of tokens that are approved (2^256-1 means infinite)
+     * @param deadline The time at which to expire the signature
+     * @param v The recovery byte of the signature
+     * @param r Half of the ECDSA signature pair
+     * @param s Half of the ECDSA signature pair
+     */
+    function permit(address owner, address spender, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) external {
+        require(deadline >= block.timestamp, "permit::expired");
+
+        bytes32 encodeData = keccak256(abi.encode(PERMIT_TYPEHASH, owner, spender, value, nonces[owner]++, deadline));
+        _validateSignedData(owner, encodeData, v, r, s);
+
+        _approve(owner, spender, value);
+    }
+
+    /**
+     * @notice Recovers address from signed data and validates the signature
+     * @param signer Address that signed the data
+     * @param encodeData Data signed by the address
+     * @param v The recovery byte of the signature
+     * @param r Half of the ECDSA signature pair
+     * @param s Half of the ECDSA signature pair
+     */
+    function _validateSignedData(address signer, bytes32 encodeData, uint8 v, bytes32 r, bytes32 s) internal view {
+        bytes32 digest = keccak256(
+            abi.encodePacked(
+                "\x19\x01",
+                getDomainSeparator(),
+                encodeData
+            )
+        );
+        address recoveredAddress = ecrecover(digest, v, r, s);
+        // Explicitly disallow authorizations for address(0) as ecrecover returns address(0) on malformed messages
+        require(recoveredAddress != address(0) && recoveredAddress == signer, "Arch::validateSig: invalid signature");
+    }
+
+    /**
+     * @notice EIP-712 Domain separator
+     * @return Separator
+     */
+    function getDomainSeparator() public view returns (bytes32) {
+        return keccak256(
+            abi.encode(
+                DOMAIN_TYPEHASH,
+                keccak256(bytes(name)),
+                VERSION_HASH,
+                _getChainId(),
+                address(this)
+            )
+        );
+    }
+
+    /**
+     * @notice Current id of the chain where this contract is deployed
+     * @return Chain id
+     */
+    function _getChainId() internal pure returns (uint) {
+        uint256 chainId;
+        assembly { chainId := chainid() }
+        return chainId;
+    }
+}
+
+
+// File contracts/YakStrategy.sol
+
+
+
+
+
+
+/**
+ * @notice YakStrategy should be inherited by new strategies
+ */
+abstract contract YakStrategy is YakERC20, Ownable, Permissioned {
+    using SafeMath for uint;
+
+    uint public totalDeposits;
+
+    IERC20 public depositToken;
+    IERC20 public rewardToken;
+    address public devAddr;
+
+    uint public MIN_TOKENS_TO_REINVEST;
+    uint public MAX_TOKENS_TO_DEPOSIT_WITHOUT_REINVEST;
+    bool public DEPOSITS_ENABLED;
+
+    uint public REINVEST_REWARD_BIPS;
+    uint public ADMIN_FEE_BIPS;
+    uint public DEV_FEE_BIPS;
+
+    uint constant internal BIPS_DIVISOR = 10000;
+    uint constant internal MAX_UINT = uint(-1);
+
+    event Deposit(address indexed account, uint amount);
+    event Withdraw(address indexed account, uint amount);
+    event Reinvest(uint newTotalDeposits, uint newTotalSupply);
+    event Recovered(address token, uint amount);
+    event UpdateAdminFee(uint oldValue, uint newValue);
+    event UpdateDevFee(uint oldValue, uint newValue);
+    event UpdateReinvestReward(uint oldValue, uint newValue);
+    event UpdateMinTokensToReinvest(uint oldValue, uint newValue);
+    event UpdateMaxTokensToDepositWithoutReinvest(uint oldValue, uint newValue);
+    event UpdateDevAddr(address oldValue, address newValue);
+    event DepositsEnabled(bool newValue);
+
+    /**
+     * @notice Throws if called by smart contract
+     */
+    modifier onlyEOA() {
+        require(tx.origin == msg.sender, "YakStrategy::onlyEOA");
+        _;
+    }
+
+    /**
+     * @notice Approve tokens for use in Strategy
+     * @dev Should use modifier `onlyOwner` to avoid griefing
+     */
+    function setAllowances() public virtual;
+
+    /**
+     * @notice Revoke token allowance
+     * @param token address
+     * @param spender address
+     */
+    function revokeAllowance(address token, address spender) external onlyOwner {
+        require(IERC20(token).approve(spender, 0));
+    }
+
+    /**
+     * @notice Deposit and deploy deposits tokens to the strategy
+     * @dev Must mint receipt tokens to `msg.sender`
+     * @param amount deposit tokens
+     */
+    function deposit(uint amount) external virtual;
+
+    /**
+    * @notice Deposit using Permit
+    * @dev Should revert for tokens without Permit
+    * @param amount Amount of tokens to deposit
+    * @param deadline The time at which to expire the signature
+    * @param v The recovery byte of the signature
+    * @param r Half of the ECDSA signature pair
+    * @param s Half of the ECDSA signature pair
+    */
+    function depositWithPermit(uint amount, uint deadline, uint8 v, bytes32 r, bytes32 s) external virtual;
+
+    /**
+     * @notice Deposit on behalf of another account
+     * @dev Must mint receipt tokens to `account`
+     * @param account address to receive receipt tokens
+     * @param amount deposit tokens
+     */
+    function depositFor(address account, uint amount) external virtual;
+
+    /**
+     * @notice Redeem receipt tokens for deposit tokens
+     * @param amount receipt tokens
+     */
+    function withdraw(uint amount) external virtual;
+
+    /**
+     * @notice Reinvest reward tokens into deposit tokens
+     */
+    function reinvest() external virtual;
+
+    /**
+     * @notice Estimate reinvest reward
+     * @return reward tokens
+     */
+    function estimateReinvestReward() external view returns (uint) {
+        uint unclaimedRewards = checkReward();
+        if (unclaimedRewards >= MIN_TOKENS_TO_REINVEST) {
+            return unclaimedRewards.mul(REINVEST_REWARD_BIPS).div(BIPS_DIVISOR);
+        }
+        return 0;
+    }
+
+    /**
+     * @notice Reward tokens avialable to strategy, including balance
+     * @return reward tokens
+     */
+    function checkReward() public virtual view returns (uint);
+
+    /**
+     * @notice Estimated deposit token balance deployed by strategy, excluding balance
+     * @return deposit tokens
+     */
+    function estimateDeployedBalance() external virtual view returns (uint);
+
+    /**
+     * @notice Rescue all available deployed deposit tokens back to Strategy
+     * @param minReturnAmountAccepted min deposit tokens to receive
+     * @param disableDeposits bool
+     */
+    function rescueDeployedFunds(uint minReturnAmountAccepted, bool disableDeposits) external virtual;
+
+    /**
+     * @notice Calculate receipt tokens for a given amount of deposit tokens
+     * @dev If contract is empty, use 1:1 ratio
+     * @dev Could return zero shares for very low amounts of deposit tokens
+     * @param amount deposit tokens
+     * @return receipt tokens
+     */
+    function getSharesForDepositTokens(uint amount) public view returns (uint) {
+        if (totalSupply.mul(totalDeposits) == 0) {
+            return amount;
+        }
+        return amount.mul(totalSupply).div(totalDeposits);
+    }
+
+    /**
+     * @notice Calculate deposit tokens for a given amount of receipt tokens
+     * @param amount receipt tokens
+     * @return deposit tokens
+     */
+    function getDepositTokensForShares(uint amount) public view returns (uint) {
+        if (totalSupply.mul(totalDeposits) == 0) {
+            return 0;
+        }
+        return amount.mul(totalDeposits).div(totalSupply);
+    }
+
+    /**
+     * @notice Update reinvest min threshold
+     * @param newValue threshold
+     */
+    function updateMinTokensToReinvest(uint newValue) public onlyOwner {
+        emit UpdateMinTokensToReinvest(MIN_TOKENS_TO_REINVEST, newValue);
+        MIN_TOKENS_TO_REINVEST = newValue;
+    }
+
+    /**
+     * @notice Update reinvest max threshold before a deposit
+     * @param newValue threshold
+     */
+    function updateMaxTokensToDepositWithoutReinvest(uint newValue) public onlyOwner {
+        emit UpdateMaxTokensToDepositWithoutReinvest(MAX_TOKENS_TO_DEPOSIT_WITHOUT_REINVEST, newValue);
+        MAX_TOKENS_TO_DEPOSIT_WITHOUT_REINVEST = newValue;
+    }
+
+    /**
+     * @notice Update developer fee
+     * @param newValue fee in BIPS
+     */
+    function updateDevFee(uint newValue) public onlyOwner {
+        require(newValue.add(ADMIN_FEE_BIPS).add(REINVEST_REWARD_BIPS) <= BIPS_DIVISOR);
+        emit UpdateDevFee(DEV_FEE_BIPS, newValue);
+        DEV_FEE_BIPS = newValue;
+    }
+
+    /**
+     * @notice Update admin fee
+     * @param newValue fee in BIPS
+     */
+    function updateAdminFee(uint newValue) public onlyOwner {
+        require(newValue.add(DEV_FEE_BIPS).add(REINVEST_REWARD_BIPS) <= BIPS_DIVISOR);
+        emit UpdateAdminFee(ADMIN_FEE_BIPS, newValue);
+        ADMIN_FEE_BIPS = newValue;
+    }
+
+    /**
+     * @notice Update reinvest reward
+     * @param newValue fee in BIPS
+     */
+    function updateReinvestReward(uint newValue) public onlyOwner {
+        require(newValue.add(ADMIN_FEE_BIPS).add(DEV_FEE_BIPS) <= BIPS_DIVISOR);
+        emit UpdateReinvestReward(REINVEST_REWARD_BIPS, newValue);
+        REINVEST_REWARD_BIPS = newValue;
+    }
+
+    /**
+     * @notice Enable/disable deposits
+     * @param newValue bool
+     */
+    function updateDepositsEnabled(bool newValue) public onlyOwner {
+        require(DEPOSITS_ENABLED != newValue);
+        DEPOSITS_ENABLED = newValue;
+        emit DepositsEnabled(newValue);
+    }
+
+    /**
+     * @notice Update devAddr
+     * @param newValue address
+     */
+    function updateDevAddr(address newValue) public {
+        require(msg.sender == devAddr);
+        emit UpdateDevAddr(devAddr, newValue);
+        devAddr = newValue;
+    }
+
+    /**
+     * @notice Recover ERC20 from contract
+     * @param tokenAddress token address
+     * @param tokenAmount amount to recover
+     */
+    function recoverERC20(address tokenAddress, uint tokenAmount) external onlyOwner {
+        require(tokenAmount > 0);
+        require(IERC20(tokenAddress).transfer(msg.sender, tokenAmount));
+        emit Recovered(tokenAddress, tokenAmount);
+    }
+
+    /**
+     * @notice Recover AVAX from contract
+     * @param amount amount
+     */
+    function recoverAVAX(uint amount) external onlyOwner {
+        require(amount > 0);
+        msg.sender.transfer(amount);
+        emit Recovered(address(0), amount);
+    }
+}
+
+
+// File contracts/interfaces/IStakingRewards.sol
+
+
+interface IStakingRewards {
+    function totalSupply() external view returns (uint256);
+    function balanceOf(address account) external view returns (uint256);
+    function lastTimeRewardApplicable() external view returns (uint256);
+    function rewardPerToken() external view returns (uint256);
+    function earned(address account) external view returns (uint256);
+    function getRewardForDuration() external view returns (uint256);
+    function stake(uint256 amount) external;
+    function stakeWithPermit(uint256 amount, uint deadline, uint8 v, bytes32 r, bytes32 s) external;
+    function withdraw(uint256 amount) external;
+    function getReward() external;
+    function exit() external;
+    event RewardAdded(uint256 reward);
+    event Staked(address indexed user, uint256 amount);
+    event Withdrawn(address indexed user, uint256 amount);
+    event RewardPaid(address indexed user, uint256 reward);
+    event RewardsDurationUpdated(uint256 newDuration);
+    event Recovered(address token, uint256 amount);
+}
+
+
+// File contracts/interfaces/IPair.sol
+
+
+interface IPair is IERC20 {
+    function token0() external pure returns (address);
+    function token1() external pure returns (address);
+    function swap(uint amount0Out, uint amount1Out, address to, bytes calldata data) external;
+    function getReserves() external view returns (uint112 reserve0, uint112 reserve1, uint32 blockTimestampLast);
+    function mint(address to) external returns (uint liquidity);
+    function sync() external;
+}
+
+
+// File contracts/strategies/DexStrategyV5Reflection.sol
+
+
+
+/**
+ * @notice Pool2 strategy for StakingRewards
+ */
+contract DexStrategyV5Reflection is YakStrategy {
+    using SafeMath for uint;
+
+    IStakingRewards public stakingContract;
+    IPair public swapPairToken0;
+    IPair public swapPairToken1;
+    bytes zeroBytes;
+    uint public burnFeeBips;
+    address public reflectionToken;
+
+    constructor (
+        string memory _name,
+        address _depositToken,
+        address _rewardToken,
+        address _stakingContract,
+        address _swapPairToken0,
+        address _swapPairToken1,
+        address _reflectionToken,
+        address _timelock,
+        uint _minTokensToReinvest,
+        uint _adminFeeBips,
+        uint _devFeeBips,
+        uint _reinvestRewardBips,
+        uint _burnFeeBips
+    ) {
+        name = _name;
+        depositToken = IERC20(_depositToken);
+        rewardToken = IERC20(_rewardToken);
+        stakingContract = IStakingRewards(_stakingContract);
+        devAddr = msg.sender;
+
+        reflectionToken = _reflectionToken;
+        assignSwapPairSafely(_swapPairToken0, _swapPairToken1, _rewardToken);
+        setAllowances();
+        updateMinTokensToReinvest(_minTokensToReinvest);
+        updateAdminFee(_adminFeeBips);
+        updateDevFee(_devFeeBips);
+        updateReinvestReward(_reinvestRewardBips);
+        updateDepositsEnabled(true);
+        updateBurnFee(_burnFeeBips);
+        transferOwnership(_timelock);
+
+        zeroBytes = new bytes(0);
+
+        emit Reinvest(0, 0);
+    }
+
+    function assignSwapPairSafely(address _swapPairToken0, address _swapPairToken1, address _rewardToken) internal {
+        if (_rewardToken != IPair(address(depositToken)).token0() && _rewardToken != IPair(address(depositToken)).token1()) {
+            // deployment checks for non-pool2
+            require(_swapPairToken0 > address(0), "Swap pair 0 is necessary but not supplied");
+            require(_swapPairToken1 > address(0), "Swap pair 1 is necessary but not supplied");
+            // should match pairToken.token0()
+            swapPairToken0 = IPair(_swapPairToken0);
+            // should match pairToken.token1()
+            swapPairToken1 = IPair(_swapPairToken1);
+            require(
+                swapPairToken0.token0() == _rewardToken || swapPairToken0.token1() == _rewardToken,
+                "Swap pair supplied does not have the reward token as one of it's pair"
+            );
+            require(
+                swapPairToken0.token0() == IPair(address(depositToken)).token0() || swapPairToken0.token1() == IPair(address(depositToken)).token0(),
+                "Swap pair 0 supplied does not match the pair in question"
+            );
+            require(
+                swapPairToken1.token0() == IPair(address(depositToken)).token1() || swapPairToken1.token1() == IPair(address(depositToken)).token1(),
+                "Swap pair 1 supplied does not match the pair in question"
+            );
+        } else if (_rewardToken == IPair(address(depositToken)).token0()) {
+            // pool2 case
+            swapPairToken1 = IPair(address(depositToken));
+        } else if (_rewardToken == IPair(address(depositToken)).token1()) {
+            // pool2 case
+            swapPairToken0 = IPair(address(depositToken));
+        }
+    }
+
+    function setAllowances() public override onlyOwner {
+        depositToken.approve(address(stakingContract), MAX_UINT);
+    }
+
+    function deposit(uint amount) external override {
+        _deposit(msg.sender, amount);
+    }
+
+    function depositWithPermit(uint amount, uint deadline, uint8 v, bytes32 r, bytes32 s) external override {
+        depositToken.permit(msg.sender, address(this), amount, deadline, v, r, s);
+        _deposit(msg.sender, amount);
+    }
+
+    function depositFor(address account, uint amount) external override {
+        _deposit(account, amount);
+    }
+
+    function _deposit(address account, uint amount) private onlyAllowedDeposits {
+        require(DEPOSITS_ENABLED == true, "DexStrategyV5::_deposit");
+        if (MAX_TOKENS_TO_DEPOSIT_WITHOUT_REINVEST > 0) {
+            uint unclaimedRewards = checkReward();
+            if (unclaimedRewards > MAX_TOKENS_TO_DEPOSIT_WITHOUT_REINVEST) {
+                _reinvest(unclaimedRewards);
+            }
+        }
+        require(depositToken.transferFrom(msg.sender, address(this), amount));
+        _stakeDepositTokens(amount);
+        _mint(account, getSharesForDepositTokens(amount));
+        totalDeposits = totalDeposits.add(amount);
+        emit Deposit(account, amount);
+    }
+
+    function withdraw(uint amount) external override {
+        uint depositTokenAmount = getDepositTokensForShares(amount);
+        if (depositTokenAmount > 0) {
+            _withdrawDepositTokens(depositTokenAmount);
+            require(depositToken.transfer(msg.sender, depositTokenAmount), "DexStrategyV5::withdraw");
+            _burn(msg.sender, amount);
+            totalDeposits = totalDeposits.sub(depositTokenAmount);
+            emit Withdraw(msg.sender, depositTokenAmount);
+        }
+    }
+
+    function _withdrawDepositTokens(uint amount) private {
+        require(amount > 0, "DexStrategyV5::_withdrawDepositTokens");
+        stakingContract.withdraw(amount);
+    }
+
+    function reinvest() external override onlyEOA {
+        uint unclaimedRewards = checkReward();
+        require(unclaimedRewards >= MIN_TOKENS_TO_REINVEST, "DexStrategyV5::reinvest");
+        _reinvest(unclaimedRewards);
+    }
+
+    /**
+     * @notice Reinvest rewards from staking contract to deposit tokens
+     * @dev Reverts if the expected amount of tokens are not returned from `stakingContract`
+     */
+    function _reinvest(uint amount) private {
+        stakingContract.getReward();
+
+        uint devFee = amount.mul(DEV_FEE_BIPS).div(BIPS_DIVISOR);
+        if (devFee > 0) {
+            require(rewardToken.transfer(devAddr, devFee), "DexStrategyV5::_reinvest, dev");
+        }
+
+        uint adminFee = amount.mul(ADMIN_FEE_BIPS).div(BIPS_DIVISOR);
+        if (adminFee > 0) {
+            require(rewardToken.transfer(owner(), adminFee), "DexStrategyV5::_reinvest, admin");
+        }
+
+        uint reinvestFee = amount.mul(REINVEST_REWARD_BIPS).div(BIPS_DIVISOR);
+        if (reinvestFee > 0) {
+            require(rewardToken.transfer(msg.sender, reinvestFee), "DexStrategyV5::_reinvest, reward");
+        }
+
+        uint depositTokenAmount = _convertRewardTokensToDepositTokens(
+            amount.sub(devFee).sub(adminFee).sub(reinvestFee)
+        );
+
+        _stakeDepositTokens(depositTokenAmount);
+        totalDeposits = totalDeposits.add(depositTokenAmount);
+
+        emit Reinvest(totalDeposits, totalSupply);
+    }
+    
+    function _stakeDepositTokens(uint amount) private {
+        require(amount > 0, "DexStrategyV5::_stakeDepositTokens");
+        stakingContract.stake(amount);
+    }
+
+    /** 
+     * @notice Given two tokens, it'll return the tokens in the right order for the tokens pair
+     * @dev TokenA must be different from TokenB, and both shouldn't be address(0), no validations
+     */
+    function sortTokens(address tokenA, address tokenB) internal pure returns (address token0, address token1) {
+        (token0, token1) = tokenA < tokenB ? (tokenA, tokenB) : (tokenB, tokenA);
+    }
+
+    /**
+     * @notice Given an input amount of an asset and pair reserves, returns maximum output amount of the other asset
+     * @dev Assumes swap fee is 0.30%
+     * @param amountIn input asset
+     * @param reserveIn size of input asset reserve
+     * @param reserveOut size of output asset reserve
+     * @return amountOut maximum output amount
+     */
+    function getAmountOut(uint amountIn, uint reserveIn, uint reserveOut) internal pure returns (uint amountOut) {
+        // this is trusting that reserveIn > 0 and reserveOut > 0
+        uint amountInWithFee = amountIn.mul(997);
+        uint numerator = amountInWithFee.mul(reserveOut);
+        uint denominator = reserveIn.mul(1000).add(amountInWithFee);
+        amountOut = numerator / denominator;
+    }
+
+    /**
+     * @notice Safely transfer using an anonymous ERC20 token
+     * @dev Requires token to return true on transfer
+     * @param token address
+     * @param to recipient address
+     * @param value amount
+     */
+    function _safeTransfer(address token, address to, uint256 value) internal {
+        require(IERC20(token).transfer(address(to), value), 'TransferHelper: TRANSFER_FROM_FAILED');
+    }
+
+    /**
+     * @notice Quote liquidity amount out
+     * @param amountIn input tokens
+     * @param reserve0 size of input asset reserve
+     * @param reserve1 size of output asset reserve
+     * @return liquidity tokens
+     */
+    function _quoteLiquidityAmountOut(uint amountIn, uint reserve0, uint reserve1) internal pure returns (uint) {
+        return amountIn.mul(reserve1).div(reserve0);
+    }
+
+    /**
+     * @notice Add liquidity directly through a Pair
+     * @dev Checks adding the max of each token amount
+     * @param token0 address
+     * @param token1 address
+     * @param maxAmountIn0 amount token0
+     * @param maxAmountIn1 amount token1
+     * @return liquidity tokens
+     */
+    function _addLiquidity(address token0, address token1, uint maxAmountIn0, uint maxAmountIn1) internal returns (uint) {
+        (uint112 reserve0, uint112 reserve1,) = IPair(address(depositToken)).getReserves();
+        // max token0, and gets the quote for token1
+        uint amountIn1 = _quoteLiquidityAmountOut(maxAmountIn0, reserve0, reserve1);
+        // if the quote exceeds our balance then max token1 instead
+        if (amountIn1 > maxAmountIn1) {
+            amountIn1 = maxAmountIn1;
+            maxAmountIn0 = _quoteLiquidityAmountOut(maxAmountIn1, reserve1, reserve0);
+        }
+        _safeTransfer(token0, address(depositToken), maxAmountIn0);
+        _safeTransfer(token1, address(depositToken), amountIn1);
+        uint minted = IPair(address(depositToken)).mint(address(this));
+        IPair(address(depositToken)).sync();
+        return minted;
+    }
+
+    /**
+     * @notice Swap directly through a Pair
+     * @param amountIn input amount
+     * @param fromToken address
+     * @param toToken address
+     * @param pair Pair used for swap
+     * @return output amount
+     */
+    function _swap(uint amountIn, address fromToken, address toToken, IPair pair) internal returns (uint) {
+        // computes the reserves in the correct pair order
+        (address token0,) = sortTokens(fromToken, toToken);
+        (uint112 reserve0, uint112 reserve1,) = pair.getReserves();
+        if (token0 != fromToken) (reserve0, reserve1) = (reserve1, reserve0);
+        // gets the expected amount out
+        uint amountOut1 = 0;
+        uint amountOut2 = getAmountOut(amountIn, reserve0, reserve1);
+        if (token0 != fromToken) (amountOut1, amountOut2) = (amountOut2, amountOut1);
+        // sends the input of the swap
+        _safeTransfer(fromToken, address(pair), amountIn);
+        // gets the output of the swap
+        pair.swap(amountOut1, amountOut2, address(this), zeroBytes);
+        if (toToken == reflectionToken) pair.sync();
+        return amountOut2 > amountOut1 ? amountOut2 : amountOut1;
+    }
+
+    /**
+     * @notice Computes how much dust of token the contract has in the reward token proportion
+     * @dev token must match the swapPair. It assumes swapPair is a pair of token-rewardToken
+     */
+    function _getDustInRewardToken(address token, IPair swapPair) internal view returns (uint) {
+        (address firstToken,) = sortTokens(address(rewardToken), token);
+        (uint112 reserve0, uint112 reserve1,) = swapPair.getReserves();
+        if (token != firstToken) (reserve0, reserve1) = (reserve1, reserve0);
+        return getAmountOut(
+            IERC20(token).balanceOf(address(this)),
+            reserve0, reserve1
+        );
+    }
+
+    /**
+     * @notice Converts reward tokens to deposit tokens
+     * @dev No price checks enforced
+     * @param amount reward tokens
+     * @return deposit tokens
+     */
+    function _convertRewardTokensToDepositTokens(uint amount) private returns (uint) {
+        uint token0BalanceFactor = _getDustInRewardToken(IPair(address(depositToken)).token0(), swapPairToken0);
+        uint token1BalanceFactor = _getDustInRewardToken(IPair(address(depositToken)).token1(), swapPairToken1);
+
+        //amount that will be burned
+        uint burnBalance = amount.mul(burnFeeBips).div(BIPS_DIVISOR);
+        //higher quantity should go into the token that will burn
+        uint amountIn0 = amount.sub(token0BalanceFactor).add(token1BalanceFactor).add(burnBalance).div(2);
+        uint amountIn1 = amount.sub(token1BalanceFactor).add(token0BalanceFactor).sub(burnBalance).div(2);
+        if (IPair(address(depositToken)).token0() != reflectionToken) {
+            (amountIn0, amountIn1) = (amountIn1, amountIn0);
+        }
+
+        // swap to token0
+        if (address(rewardToken) != IPair(address(depositToken)).token0()) {
+            _swap(
+                amountIn0, address(rewardToken),
+                IPair(address(depositToken)).token0(), swapPairToken0
+            );
+        }
+
+        // swap to token1
+        if (address(rewardToken) != IPair(address(depositToken)).token1()) {
+            _swap(
+                amountIn1, address(rewardToken),
+                IPair(address(depositToken)).token1(), swapPairToken1
+            );
+        }
+
+        return _addLiquidity(
+            IPair(address(depositToken)).token0(), IPair(address(depositToken)).token1(),
+            IERC20(IPair(address(depositToken)).token0()).balanceOf(address(this)),
+            IERC20(IPair(address(depositToken)).token1()).balanceOf(address(this))
+        );
+    }
+    
+    function checkReward() public override view returns (uint) {
+        return stakingContract.earned(address(this));
+    }
+
+    function estimateDeployedBalance() external override view returns (uint) {
+        return stakingContract.balanceOf(address(this));
+    }
+
+    /**
+     * @notice Updates the burning fee associated with the reflection token
+     * @dev No checks, incorrect value here might cause reinvest to fail due to balance miscalculation
+     * @param _burnFeeBips burn fee in bips meaning the percentage that the reflection burns in total
+     */
+    function updateBurnFee(uint _burnFeeBips) public onlyOwner {
+        burnFeeBips = _burnFeeBips;
+    }
+
+    function rescueDeployedFunds(uint minReturnAmountAccepted, bool disableDeposits) external override onlyOwner {
+        uint balanceBefore = depositToken.balanceOf(address(this));
+        stakingContract.exit();
+        uint balanceAfter = depositToken.balanceOf(address(this));
+        require(balanceAfter.sub(balanceBefore) >= minReturnAmountAccepted, "DexStrategyV4::rescueDeployedFunds");
+        totalDeposits = balanceAfter;
+        emit Reinvest(totalDeposits, totalSupply);
+        if (DEPOSITS_ENABLED == true && disableDeposits == true) {
+            updateDepositsEnabled(false);
+        }
+    }
+}


### PR DESCRIPTION
The PR is ready for review/merging.

Tested:
1. SHIBX-WAVAX from Baguette, 10% burnFee, worked flawless for the amount of liquidity that I could provide
2. SPORE-WAVAX from Olive, 6% burnFee, this one required an extra hacking because Olive contract is not compatible with the default StakingRewards, but the changes only affected the stakingReward, not the Reinvest.
3. Deployed to FUJI
4. Verified the contract [here](https://cchain.explorer.avax-test.network/address/0x732BF0Cdf8fA2f88908F4008748866F9C9eeBeCB/contracts)

In regards to verification of the contract, this one give me a bit of a headache, turns out our previous pattern to identify the ABI constructor (8be...) did not work in this contract, so I had to develop a methodology to identify the new constructor. For this contract the first streak of zeros after the compiler metadata divisor(0007030033).

Here's the constructor used in Fuji dor SHIBX-WAVAX.

```
00000000000000000000000000000000000000000000000000000000000001a0000000000000000000000000d4150762dd6c3621afdee887aab091df269db11a000000000000000000000000a1144a6a1304bd9cbb16c800f7a867508726566e000000000000000000000000e958dcc86632d7421a86133026423a232ea2212e00000000000000000000000073a5bc09387798ae890f7f2c084f38840d06d5a50000000000000000000000001fbd931ae22a7ab0e16ae57edafe00320fe94692000000000000000000000000440abbf18c54b2782a4917b80a1746d3a2c2cce10000000000000000000000008d36c5c6947adccd25ef49ea1aac2ceacfff0bd700000000000000000000000000000000000000000000000000000000000003e8000000000000000000000000000000000000000000000000016345785d8a000000000000000000000000000000000000000000000000000000000000000000c800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000320000000000000000000000000000000000000000000000000000000000000001a5969656c642059616b3a2042474c2053484942582d5741564158000000000000
```

Alternatively, we can use https://abi.hashex.org/ to generate the constructor, but the constructor generated will *NOT* work. But it'll give you a hint from where you should start copying the constructor from in the deployment transaction log.

This contract keeps an amount of dust in it by design, this dust is necessary to keep the balance between the two coins and the burning. We still haven't figured out a way to make this work without the dust. The dust amount should be static and very small