### PR TITLE
Role based timelock

### DIFF
--- a/contracts/helpers/TimelockRoleHelper.sol
+++ b/contracts/helpers/TimelockRoleHelper.sol
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+import "../lib/AccessControl.sol";
+
+contract TimelockRoleHelper is AccessControl{
+
+    constructor() {}
+
+    bytes32 public constant setTimelock_ADMIN = keccak256("setTimelock_ADMIN");
+    bytes32 public constant allowDepositor_ADMIN = keccak256("allowDepositor_ADMIN");
+    bytes32 public constant emergencyWithdraw_ADMIN = keccak256("emergencyWithdraw_ADMIN");
+    bytes32 public constant proposeAdminFee_ADMIN = keccak256("proposeAdminFee_ADMIN");
+    bytes32 public constant proposeDevFee_ADMIN = keccak256("proposeDevFee_ADMIN");
+    bytes32 public constant proposeOwner_ADMIN = keccak256("proposeOwner_ADMIN");
+    bytes32 public constant proposeRecoverAVAX_ADMIN = keccak256("proposeRecoverAVAX_ADMIN");
+    bytes32 public constant proposeRecoverERC20_ADMIN = keccak256("proposeRecoverERC20_ADMIN");
+    bytes32 public constant proposeReinvestReward_ADMIN = keccak256("proposeReinvestReward_ADMIN");
+    bytes32 public constant removeDepositor_ADMIN = keccak256("removeDepositor_ADMIN");
+    bytes32 public constant rescueDeployedFunds_ADMIN = keccak256("rescueDeployedFunds_ADMIN");
+    bytes32 public constant setAdminFee_ADMIN = keccak256("setAdminFee_ADMIN");
+    bytes32 public constant setAllowances_ADMIN = keccak256("setAllowances_ADMIN");
+    bytes32 public constant setDepositsEnabled_ADMIN = keccak256("setDepositsEnabled_ADMIN");
+    bytes32 public constant setDevFee_ADMIN = keccak256("setDevFee_ADMIN");
+    bytes32 public constant setMaxTokensToDepositWithoutReinvest_ADMIN = keccak256("setMaxTokensToDepositWithoutReinvest_ADMIN");
+    bytes32 public constant setMinTokensToReinvest_ADMIN = keccak256("setMinTokensToReinvest_ADMIN");
+    bytes32 public constant setOwner_ADMIN = keccak256("setOwner_ADMIN");
+    bytes32 public constant setRecoverAVAX_ADMIN = keccak256("setRecoverAVAX_ADMIN");
+    bytes32 public constant setRecoverERC20_ADMIN = keccak256("setRecoverERC20_ADMIN");
+    bytes32 public constant setReinvestReward_ADMIN = keccak256("setReinvestReward_ADMIN");
+    bytes32 public constant sweepAVAX_ADMIN = keccak256("sweepAVAX_ADMIN");
+    bytes32 public constant sweepTokens_ADMIN = keccak256("sweepTokens_ADMIN");
+
+        // Modifiers
+
+    /**
+     * @notice Restrict to `setTimelock`
+     * @dev To change, call revokeRole with setTimelock_ADMIN
+     */
+    modifier onlysetTimelock_ADMIN {
+        require(hasRole(setTimelock_ADMIN, msg.sender), "Caller is not setTimelock_ADMIN");
+        _;
+    }
+
+    /**
+     * @notice Restrict to `allowDepositor`
+     * @dev To change, call revokeRole with allowDepositor_ADMIN
+     */
+    modifier onlyallowDepositor_ADMIN {
+        require(hasRole(allowDepositor_ADMIN, msg.sender), "Caller is not allowDepositor_ADMIN");
+        _;
+    }
+
+    /**
+     * @notice Restrict to `emergencyWithdraw`
+     * @dev To change, call revokeRole with emergencyWithdraw_ADMIN
+     */
+    modifier onlyemergencyWithdraw_ADMIN {
+        require(hasRole(emergencyWithdraw_ADMIN, msg.sender), "Caller is not emergencyWithdraw_ADMIN");
+        _;
+    }
+
+    /**
+     * @notice Restrict to `proposeAdminFee`
+     * @dev To change, call revokeRole with proposeAdminFee_ADMIN
+     */
+    modifier onlyproposeAdminFee_ADMIN {
+        require(hasRole(proposeAdminFee_ADMIN, msg.sender), "Caller is not proposeAdminFee_ADMIN");
+        _;
+    }
+
+    /**
+     * @notice Restrict to `proposeDevFee`
+     * @dev To change, call revokeRole with proposeDevFee_ADMIN
+     */
+    modifier onlyproposeDevFee_ADMIN {
+        require(hasRole(proposeDevFee_ADMIN, msg.sender), "Caller is not proposeDevFee_ADMIN");
+        _;
+    }
+
+    /**
+     * @notice Restrict to `proposeOwner`
+     * @dev To change, call revokeRole with proposeOwner_ADMIN
+     */
+    modifier onlyproposeOwner_ADMIN {
+        require(hasRole(proposeOwner_ADMIN, msg.sender), "Caller is not proposeOwner_ADMIN");
+        _;
+    }
+
+    /**
+     * @notice Restrict to `proposeRecoverAVAX`
+     * @dev To change, call revokeRole with proposeRecoverAVAX_ADMIN
+     */
+    modifier onlyproposeRecoverAVAX_ADMIN {
+        require(hasRole(proposeRecoverAVAX_ADMIN, msg.sender), "Caller is not proposeRecoverAVAX_ADMIN");
+        _;
+    }
+
+    /**
+     * @notice Restrict to `proposeRecoverERC20`
+     * @dev To change, call revokeRole with proposeRecoverERC20_ADMIN
+     */
+    modifier onlyproposeRecoverERC20_ADMIN {
+        require(hasRole(proposeRecoverERC20_ADMIN, msg.sender), "Caller is not proposeRecoverERC20_ADMIN");
+        _;
+    }
+
+    /**
+     * @notice Restrict to `proposeReinvestReward`
+     * @dev To change, call revokeRole with proposeReinvestReward_ADMIN
+     */
+    modifier onlyproposeReinvestReward_ADMIN {
+        require(hasRole(proposeReinvestReward_ADMIN, msg.sender), "Caller is not proposeReinvestReward_ADMIN");
+        _;
+    }
+
+    /**
+     * @notice Restrict to `removeDepositor`
+     * @dev To change, call revokeRole with removeDepositor_ADMIN
+     */
+    modifier onlyremoveDepositor_ADMIN {
+        require(hasRole(removeDepositor_ADMIN, msg.sender), "Caller is not removeDepositor_ADMIN");
+        _;
+    }
+
+    /**
+     * @notice Restrict to `rescueDeployedFunds`
+     * @dev To change, call revokeRole with rescueDeployedFunds_ADMIN
+     */
+    modifier onlyrescueDeployedFunds_ADMIN {
+        require(hasRole(rescueDeployedFunds_ADMIN, msg.sender), "Caller is not rescueDeployedFunds_ADMIN");
+        _;
+    }
+
+    /**
+     * @notice Restrict to `setAdminFee`
+     * @dev To change, call revokeRole with setAdminFee_ADMIN
+     */
+    modifier onlysetAdminFee_ADMIN {
+        require(hasRole(setAdminFee_ADMIN, msg.sender), "Caller is not setAdminFee_ADMIN");
+        _;
+    }
+
+    /**
+     * @notice Restrict to `setAllowances`
+     * @dev To change, call revokeRole with setAllowances_ADMIN
+     */
+    modifier onlysetAllowances_ADMIN {
+        require(hasRole(setAllowances_ADMIN, msg.sender), "Caller is not setAllowances_ADMIN");
+        _;
+    }
+
+    /**
+     * @notice Restrict to `setDepositsEnabled`
+     * @dev To change, call revokeRole with setDepositsEnabled_ADMIN
+     */
+    modifier onlysetDepositsEnabled_ADMIN {
+        require(hasRole(setDepositsEnabled_ADMIN, msg.sender), "Caller is not setDepositsEnabled_ADMIN");
+        _;
+    }
+
+    /**
+     * @notice Restrict to `setDevFee`
+     * @dev To change, call revokeRole with setDevFee_ADMIN
+     */
+    modifier onlysetDevFee_ADMIN {
+        require(hasRole(setDevFee_ADMIN, msg.sender), "Caller is not setDevFee_ADMIN");
+        _;
+    }
+
+    /**
+     * @notice Restrict to `setMaxTokensToDepositWithoutReinvest`
+     * @dev To change, call revokeRole with setMaxTokensToDepositWithoutReinvest_ADMIN
+     */
+    modifier onlysetMaxTokensToDepositWithoutReinvest_ADMIN {
+        require(hasRole(setMaxTokensToDepositWithoutReinvest_ADMIN, msg.sender), "Caller is not setMaxTokensToDepositWithoutReinvest_ADMIN");
+        _;
+    }
+
+    /**
+     * @notice Restrict to `setMinTokensToReinvest`
+     * @dev To change, call revokeRole with setMinTokensToReinvest_ADMIN
+     */
+    modifier onlysetMinTokensToReinvest_ADMIN {
+        require(hasRole(setMinTokensToReinvest_ADMIN, msg.sender), "Caller is not setMinTokensToReinvest_ADMIN");
+        _;
+    }
+
+    /**
+     * @notice Restrict to `setOwner`
+     * @dev To change, call revokeRole with setOwner_ADMIN
+     */
+    modifier onlysetOwner_ADMIN {
+        require(hasRole(setOwner_ADMIN, msg.sender), "Caller is not setOwner_ADMIN");
+        _;
+    }
+
+    /**
+     * @notice Restrict to `setRecoverAVAX`
+     * @dev To change, call revokeRole with setRecoverAVAX_ADMIN
+     */
+    modifier onlysetRecoverAVAX_ADMIN {
+        require(hasRole(setRecoverAVAX_ADMIN, msg.sender), "Caller is not setRecoverAVAX_ADMIN");
+        _;
+    }
+
+    /**
+     * @notice Restrict to `setRecoverERC20`
+     * @dev To change, call revokeRole with setRecoverERC20_ADMIN
+     */
+    modifier onlysetRecoverERC20_ADMIN {
+        require(hasRole(setRecoverERC20_ADMIN, msg.sender), "Caller is not setRecoverERC20_ADMIN");
+        _;
+    }
+
+    /**
+     * @notice Restrict to `setReinvestReward`
+     * @dev To change, call revokeRole with setReinvestReward_ADMIN
+     */
+    modifier onlysetReinvestReward_ADMIN {
+        require(hasRole(setReinvestReward_ADMIN, msg.sender), "Caller is not setReinvestReward_ADMIN");
+        _;
+    }
+
+    /**
+     * @notice Restrict to `sweepAVAX`
+     * @dev To change, call revokeRole with sweepAVAX_ADMIN
+     */
+    modifier onlysweepAVAX_ADMIN {
+        require(hasRole(sweepAVAX_ADMIN, msg.sender), "Caller is not sweepAVAX_ADMIN");
+        _;
+    }
+
+    /**
+     * @notice Restrict to `sweepTokens`
+     * @dev To change, call revokeRole with sweepTokens_ADMIN
+     */
+    modifier onlysweepTokens_ADMIN {
+        require(hasRole(sweepTokens_ADMIN, msg.sender), "Caller is not sweepTokens_ADMIN");
+        _;
+    }
+
+}

--- a/contracts/interfaces/IYakStrategy.sol
+++ b/contracts/interfaces/IYakStrategy.sol
@@ -4,4 +4,5 @@ pragma solidity ^0.7.0;
 interface IYakStrategy {
     function depositToken() external view returns (address);
     function depositFor(address account, uint amount) external;
+    function withdraw(uint amount) external;
 }

--- a/contracts/lib/AccessControl.sol
+++ b/contracts/lib/AccessControl.sol
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.6.0 <0.8.0;
+
+import "./EnumerableSet.sol";
+import "./Address.sol";
+import "./Context.sol";
+
+/**
+ * @dev Contract module that allows children to implement role-based access
+ * control mechanisms.
+ *
+ * Roles are referred to by their `bytes32` identifier. These should be exposed
+ * in the external API and be unique. The best way to achieve this is by
+ * using `public constant` hash digests:
+ *
+ * ```
+ * bytes32 public constant MY_ROLE = keccak256("MY_ROLE");
+ * ```
+ *
+ * Roles can be used to represent a set of permissions. To restrict access to a
+ * function call, use {hasRole}:
+ *
+ * ```
+ * function foo() public {
+ *     require(hasRole(MY_ROLE, msg.sender));
+ *     ...
+ * }
+ * ```
+ *
+ * Roles can be granted and revoked dynamically via the {grantRole} and
+ * {revokeRole} functions. Each role has an associated admin role, and only
+ * accounts that have a role's admin role can call {grantRole} and {revokeRole}.
+ *
+ * By default, the admin role for all roles is `DEFAULT_ADMIN_ROLE`, which means
+ * that only accounts with this role will be able to grant or revoke other
+ * roles. More complex role relationships can be created by using
+ * {_setRoleAdmin}.
+ *
+ * WARNING: The `DEFAULT_ADMIN_ROLE` is also its own admin: it has permission to
+ * grant and revoke this role. Extra precautions should be taken to secure
+ * accounts that have been granted it.
+ */
+abstract contract AccessControl is Context {
+    using EnumerableSet for EnumerableSet.AddressSet;
+    using Address for address;
+
+    struct RoleData {
+        EnumerableSet.AddressSet members;
+        bytes32 adminRole;
+    }
+
+    mapping (bytes32 => RoleData) private _roles;
+
+    bytes32 public constant DEFAULT_ADMIN_ROLE = 0x00;
+
+    /**
+     * @dev Emitted when `newAdminRole` is set as ``role``'s admin role, replacing `previousAdminRole`
+     *
+     * `DEFAULT_ADMIN_ROLE` is the starting admin for all roles, despite
+     * {RoleAdminChanged} not being emitted signaling this.
+     *
+     * _Available since v3.1._
+     */
+    event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole);
+
+    /**
+     * @dev Emitted when `account` is granted `role`.
+     *
+     * `sender` is the account that originated the contract call, an admin role
+     * bearer except when using {_setupRole}.
+     */
+    event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender);
+
+    /**
+     * @dev Emitted when `account` is revoked `role`.
+     *
+     * `sender` is the account that originated the contract call:
+     *   - if using `revokeRole`, it is the admin role bearer
+     *   - if using `renounceRole`, it is the role bearer (i.e. `account`)
+     */
+    event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender);
+
+    /**
+     * @dev Returns `true` if `account` has been granted `role`.
+     */
+    function hasRole(bytes32 role, address account) public view returns (bool) {
+        return _roles[role].members.contains(account);
+    }
+
+    /**
+     * @dev Returns the number of accounts that have `role`. Can be used
+     * together with {getRoleMember} to enumerate all bearers of a role.
+     */
+    function getRoleMemberCount(bytes32 role) public view returns (uint256) {
+        return _roles[role].members.length();
+    }
+
+    /**
+     * @dev Returns one of the accounts that have `role`. `index` must be a
+     * value between 0 and {getRoleMemberCount}, non-inclusive.
+     *
+     * Role bearers are not sorted in any particular way, and their ordering may
+     * change at any point.
+     *
+     * WARNING: When using {getRoleMember} and {getRoleMemberCount}, make sure
+     * you perform all queries on the same block. See the following
+     * https://forum.openzeppelin.com/t/iterating-over-elements-on-enumerableset-in-openzeppelin-contracts/2296[forum post]
+     * for more information.
+     */
+    function getRoleMember(bytes32 role, uint256 index) public view returns (address) {
+        return _roles[role].members.at(index);
+    }
+
+    /**
+     * @dev Returns the admin role that controls `role`. See {grantRole} and
+     * {revokeRole}.
+     *
+     * To change a role's admin, use {_setRoleAdmin}.
+     */
+    function getRoleAdmin(bytes32 role) public view returns (bytes32) {
+        return _roles[role].adminRole;
+    }
+
+    /**
+     * @dev Grants `role` to `account`.
+     *
+     * If `account` had not been already granted `role`, emits a {RoleGranted}
+     * event.
+     *
+     * Requirements:
+     *
+     * - the caller must have ``role``'s admin role.
+     */
+    function grantRole(bytes32 role, address account) public virtual {
+        require(hasRole(_roles[role].adminRole, _msgSender()), "AccessControl: sender must be an admin to grant");
+
+        _grantRole(role, account);
+    }
+
+    /**
+     * @dev Revokes `role` from `account`.
+     *
+     * If `account` had been granted `role`, emits a {RoleRevoked} event.
+     *
+     * Requirements:
+     *
+     * - the caller must have ``role``'s admin role.
+     */
+    function revokeRole(bytes32 role, address account) public virtual {
+        require(hasRole(_roles[role].adminRole, _msgSender()), "AccessControl: sender must be an admin to revoke");
+
+        _revokeRole(role, account);
+    }
+
+    /**
+     * @dev Revokes `role` from the calling account.
+     *
+     * Roles are often managed via {grantRole} and {revokeRole}: this function's
+     * purpose is to provide a mechanism for accounts to lose their privileges
+     * if they are compromised (such as when a trusted device is misplaced).
+     *
+     * If the calling account had been granted `role`, emits a {RoleRevoked}
+     * event.
+     *
+     * Requirements:
+     *
+     * - the caller must be `account`.
+     */
+    function renounceRole(bytes32 role, address account) public virtual {
+        require(account == _msgSender(), "AccessControl: can only renounce roles for self");
+
+        _revokeRole(role, account);
+    }
+
+    /**
+     * @dev Grants `role` to `account`.
+     *
+     * If `account` had not been already granted `role`, emits a {RoleGranted}
+     * event. Note that unlike {grantRole}, this function doesn't perform any
+     * checks on the calling account.
+     *
+     * [WARNING]
+     * ====
+     * This function should only be called from the constructor when setting
+     * up the initial roles for the system.
+     *
+     * Using this function in any other way is effectively circumventing the admin
+     * system imposed by {AccessControl}.
+     * ====
+     */
+    function _setupRole(bytes32 role, address account) internal virtual {
+        _grantRole(role, account);
+    }
+
+    /**
+     * @dev Sets `adminRole` as ``role``'s admin role.
+     *
+     * Emits a {RoleAdminChanged} event.
+     */
+    function _setRoleAdmin(bytes32 role, bytes32 adminRole) internal virtual {
+        emit RoleAdminChanged(role, _roles[role].adminRole, adminRole);
+        _roles[role].adminRole = adminRole;
+    }
+
+    function _grantRole(bytes32 role, address account) private {
+        if (_roles[role].members.add(account)) {
+            emit RoleGranted(role, account, _msgSender());
+        }
+    }
+
+    function _revokeRole(bytes32 role, address account) private {
+        if (_roles[role].members.remove(account)) {
+            emit RoleRevoked(role, account, _msgSender());
+        }
+    }
+}

--- a/contracts/lib/Address.sol
+++ b/contracts/lib/Address.sol
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.6.2 <0.8.0;
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library Address {
+    /**
+     * @dev Returns true if `account` is a contract.
+     *
+     * [IMPORTANT]
+     * ====
+     * It is unsafe to assume that an address for which this function returns
+     * false is an externally-owned account (EOA) and not a contract.
+     *
+     * Among others, `isContract` will return false for the following
+     * types of addresses:
+     *
+     *  - an externally-owned account
+     *  - a contract in construction
+     *  - an address where a contract will be created
+     *  - an address where a contract lived, but was destroyed
+     * ====
+     */
+    function isContract(address account) internal view returns (bool) {
+        // This method relies on extcodesize, which returns 0 for contracts in
+        // construction, since the code is only stored at the end of the
+        // constructor execution.
+
+        uint256 size;
+        // solhint-disable-next-line no-inline-assembly
+        assembly { size := extcodesize(account) }
+        return size > 0;
+    }
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * IMPORTANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        // solhint-disable-next-line avoid-low-level-calls, avoid-call-value
+        (bool success, ) = recipient.call{ value: amount }("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain`call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason, it is bubbled up by this
+     * function (like regular Solidity function calls).
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
+      return functionCall(target, data, "Address: low-level call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with
+     * `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, 0, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, value, "Address: low-level call with value failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but
+     * with `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(address target, bytes memory data, uint256 value, string memory errorMessage) internal returns (bytes memory) {
+        require(address(this).balance >= value, "Address: insufficient balance for call");
+        require(isContract(target), "Address: call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.call{ value: value }(data);
+        return _verifyCallResult(success, returndata, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but performing a static call.
+     *
+     * _Available since v3.3._
+     */
+    function functionStaticCall(address target, bytes memory data) internal view returns (bytes memory) {
+        return functionStaticCall(target, data, "Address: low-level static call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-string-}[`functionCall`],
+     * but performing a static call.
+     *
+     * _Available since v3.3._
+     */
+    function functionStaticCall(address target, bytes memory data, string memory errorMessage) internal view returns (bytes memory) {
+        require(isContract(target), "Address: static call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.staticcall(data);
+        return _verifyCallResult(success, returndata, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but performing a delegate call.
+     *
+     * _Available since v3.4._
+     */
+    function functionDelegateCall(address target, bytes memory data) internal returns (bytes memory) {
+        return functionDelegateCall(target, data, "Address: low-level delegate call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-string-}[`functionCall`],
+     * but performing a delegate call.
+     *
+     * _Available since v3.4._
+     */
+    function functionDelegateCall(address target, bytes memory data, string memory errorMessage) internal returns (bytes memory) {
+        require(isContract(target), "Address: delegate call to non-contract");
+
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returndata) = target.delegatecall(data);
+        return _verifyCallResult(success, returndata, errorMessage);
+    }
+
+    function _verifyCallResult(bool success, bytes memory returndata, string memory errorMessage) private pure returns(bytes memory) {
+        if (success) {
+            return returndata;
+        } else {
+            // Look for revert reason and bubble it up if present
+            if (returndata.length > 0) {
+                // The easiest way to bubble the revert reason is using memory via assembly
+
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    let returndata_size := mload(returndata)
+                    revert(add(32, returndata), returndata_size)
+                }
+            } else {
+                revert(errorMessage);
+            }
+        }
+    }
+}

--- a/contracts/lib/EnumerableSet.sol
+++ b/contracts/lib/EnumerableSet.sol
@@ -1,0 +1,297 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.6.0 <0.8.0;
+
+/**
+ * @dev Library for managing
+ * https://en.wikipedia.org/wiki/Set_(abstract_data_type)[sets] of primitive
+ * types.
+ *
+ * Sets have the following properties:
+ *
+ * - Elements are added, removed, and checked for existence in constant time
+ * (O(1)).
+ * - Elements are enumerated in O(n). No guarantees are made on the ordering.
+ *
+ * ```
+ * contract Example {
+ *     // Add the library methods
+ *     using EnumerableSet for EnumerableSet.AddressSet;
+ *
+ *     // Declare a set state variable
+ *     EnumerableSet.AddressSet private mySet;
+ * }
+ * ```
+ *
+ * As of v3.3.0, sets of type `bytes32` (`Bytes32Set`), `address` (`AddressSet`)
+ * and `uint256` (`UintSet`) are supported.
+ */
+library EnumerableSet {
+    // To implement this library for multiple types with as little code
+    // repetition as possible, we write it in terms of a generic Set type with
+    // bytes32 values.
+    // The Set implementation uses private functions, and user-facing
+    // implementations (such as AddressSet) are just wrappers around the
+    // underlying Set.
+    // This means that we can only create new EnumerableSets for types that fit
+    // in bytes32.
+
+    struct Set {
+        // Storage of set values
+        bytes32[] _values;
+
+        // Position of the value in the `values` array, plus 1 because index 0
+        // means a value is not in the set.
+        mapping (bytes32 => uint256) _indexes;
+    }
+
+    /**
+     * @dev Add a value to a set. O(1).
+     *
+     * Returns true if the value was added to the set, that is if it was not
+     * already present.
+     */
+    function _add(Set storage set, bytes32 value) private returns (bool) {
+        if (!_contains(set, value)) {
+            set._values.push(value);
+            // The value is stored at length-1, but we add 1 to all indexes
+            // and use 0 as a sentinel value
+            set._indexes[value] = set._values.length;
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * @dev Removes a value from a set. O(1).
+     *
+     * Returns true if the value was removed from the set, that is if it was
+     * present.
+     */
+    function _remove(Set storage set, bytes32 value) private returns (bool) {
+        // We read and store the value's index to prevent multiple reads from the same storage slot
+        uint256 valueIndex = set._indexes[value];
+
+        if (valueIndex != 0) { // Equivalent to contains(set, value)
+            // To delete an element from the _values array in O(1), we swap the element to delete with the last one in
+            // the array, and then remove the last element (sometimes called as 'swap and pop').
+            // This modifies the order of the array, as noted in {at}.
+
+            uint256 toDeleteIndex = valueIndex - 1;
+            uint256 lastIndex = set._values.length - 1;
+
+            // When the value to delete is the last one, the swap operation is unnecessary. However, since this occurs
+            // so rarely, we still do the swap anyway to avoid the gas cost of adding an 'if' statement.
+
+            bytes32 lastvalue = set._values[lastIndex];
+
+            // Move the last value to the index where the value to delete is
+            set._values[toDeleteIndex] = lastvalue;
+            // Update the index for the moved value
+            set._indexes[lastvalue] = toDeleteIndex + 1; // All indexes are 1-based
+
+            // Delete the slot where the moved value was stored
+            set._values.pop();
+
+            // Delete the index for the deleted slot
+            delete set._indexes[value];
+
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * @dev Returns true if the value is in the set. O(1).
+     */
+    function _contains(Set storage set, bytes32 value) private view returns (bool) {
+        return set._indexes[value] != 0;
+    }
+
+    /**
+     * @dev Returns the number of values on the set. O(1).
+     */
+    function _length(Set storage set) private view returns (uint256) {
+        return set._values.length;
+    }
+
+   /**
+    * @dev Returns the value stored at position `index` in the set. O(1).
+    *
+    * Note that there are no guarantees on the ordering of values inside the
+    * array, and it may change when more values are added or removed.
+    *
+    * Requirements:
+    *
+    * - `index` must be strictly less than {length}.
+    */
+    function _at(Set storage set, uint256 index) private view returns (bytes32) {
+        require(set._values.length > index, "EnumerableSet: index out of bounds");
+        return set._values[index];
+    }
+
+    // Bytes32Set
+
+    struct Bytes32Set {
+        Set _inner;
+    }
+
+    /**
+     * @dev Add a value to a set. O(1).
+     *
+     * Returns true if the value was added to the set, that is if it was not
+     * already present.
+     */
+    function add(Bytes32Set storage set, bytes32 value) internal returns (bool) {
+        return _add(set._inner, value);
+    }
+
+    /**
+     * @dev Removes a value from a set. O(1).
+     *
+     * Returns true if the value was removed from the set, that is if it was
+     * present.
+     */
+    function remove(Bytes32Set storage set, bytes32 value) internal returns (bool) {
+        return _remove(set._inner, value);
+    }
+
+    /**
+     * @dev Returns true if the value is in the set. O(1).
+     */
+    function contains(Bytes32Set storage set, bytes32 value) internal view returns (bool) {
+        return _contains(set._inner, value);
+    }
+
+    /**
+     * @dev Returns the number of values in the set. O(1).
+     */
+    function length(Bytes32Set storage set) internal view returns (uint256) {
+        return _length(set._inner);
+    }
+
+   /**
+    * @dev Returns the value stored at position `index` in the set. O(1).
+    *
+    * Note that there are no guarantees on the ordering of values inside the
+    * array, and it may change when more values are added or removed.
+    *
+    * Requirements:
+    *
+    * - `index` must be strictly less than {length}.
+    */
+    function at(Bytes32Set storage set, uint256 index) internal view returns (bytes32) {
+        return _at(set._inner, index);
+    }
+
+    // AddressSet
+
+    struct AddressSet {
+        Set _inner;
+    }
+
+    /**
+     * @dev Add a value to a set. O(1).
+     *
+     * Returns true if the value was added to the set, that is if it was not
+     * already present.
+     */
+    function add(AddressSet storage set, address value) internal returns (bool) {
+        return _add(set._inner, bytes32(uint256(uint160(value))));
+    }
+
+    /**
+     * @dev Removes a value from a set. O(1).
+     *
+     * Returns true if the value was removed from the set, that is if it was
+     * present.
+     */
+    function remove(AddressSet storage set, address value) internal returns (bool) {
+        return _remove(set._inner, bytes32(uint256(uint160(value))));
+    }
+
+    /**
+     * @dev Returns true if the value is in the set. O(1).
+     */
+    function contains(AddressSet storage set, address value) internal view returns (bool) {
+        return _contains(set._inner, bytes32(uint256(uint160(value))));
+    }
+
+    /**
+     * @dev Returns the number of values in the set. O(1).
+     */
+    function length(AddressSet storage set) internal view returns (uint256) {
+        return _length(set._inner);
+    }
+
+   /**
+    * @dev Returns the value stored at position `index` in the set. O(1).
+    *
+    * Note that there are no guarantees on the ordering of values inside the
+    * array, and it may change when more values are added or removed.
+    *
+    * Requirements:
+    *
+    * - `index` must be strictly less than {length}.
+    */
+    function at(AddressSet storage set, uint256 index) internal view returns (address) {
+        return address(uint160(uint256(_at(set._inner, index))));
+    }
+
+
+    // UintSet
+
+    struct UintSet {
+        Set _inner;
+    }
+
+    /**
+     * @dev Add a value to a set. O(1).
+     *
+     * Returns true if the value was added to the set, that is if it was not
+     * already present.
+     */
+    function add(UintSet storage set, uint256 value) internal returns (bool) {
+        return _add(set._inner, bytes32(value));
+    }
+
+    /**
+     * @dev Removes a value from a set. O(1).
+     *
+     * Returns true if the value was removed from the set, that is if it was
+     * present.
+     */
+    function remove(UintSet storage set, uint256 value) internal returns (bool) {
+        return _remove(set._inner, bytes32(value));
+    }
+
+    /**
+     * @dev Returns true if the value is in the set. O(1).
+     */
+    function contains(UintSet storage set, uint256 value) internal view returns (bool) {
+        return _contains(set._inner, bytes32(value));
+    }
+
+    /**
+     * @dev Returns the number of values on the set. O(1).
+     */
+    function length(UintSet storage set) internal view returns (uint256) {
+        return _length(set._inner);
+    }
+
+   /**
+    * @dev Returns the value stored at position `index` in the set. O(1).
+    *
+    * Note that there are no guarantees on the ordering of values inside the
+    * array, and it may change when more values are added or removed.
+    *
+    * Requirements:
+    *
+    * - `index` must be strictly less than {length}.
+    */
+    function at(UintSet storage set, uint256 index) internal view returns (uint256) {
+        return uint256(_at(set._inner, index));
+    }
+}

--- a/contracts/timelocks/YakTimelockForDexStrategyV4.sol
+++ b/contracts/timelocks/YakTimelockForDexStrategyV4.sol
@@ -1,0 +1,402 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.7.0;
+
+
+import "../lib/Ownable.sol";
+import "../helpers/TimelockRoleHelper.sol";
+interface IERC20 {
+    function transfer(address recipient, uint256 amount) external returns (bool);
+}
+
+interface IStrategy {
+    function owner() external view returns (address);
+    function renounceOwnership() external;
+    function transferOwnership(address newOwner) external;
+    function emergencyWithdraw() external;
+    function updateMinTokensToReinvest(uint newValue) external;
+    function updateAdminFee(uint newValue) external;
+    function updateDevFee(uint newValue) external;
+    function updateDepositsEnabled(bool newValue) external;
+    function updateMaxTokensToDepositWithoutReinvest(uint newValue) external;
+    function rescueDeployedFunds(uint minReturnAmountAccepted, bool disableDeposits) external;
+    function updateReinvestReward(uint newValue) external;
+    function recoverERC20(address tokenAddress, uint tokenAmount) external;
+    function recoverAVAX(uint amount) external;
+    function setAllowances() external;
+    function allowDepositor(address depositor) external;
+    function removeDepositor(address depositor) external;
+}
+
+/**
+ * @notice A generic timelock for YakStrategies
+ * @dev Ensure function is supported by strategy
+ */
+contract YakTimelockForDexStrategyV4 is Ownable,TimelockRoleHelper {
+
+    uint public constant timelockLengthForAssetRecovery = 2 days;
+    uint public constant timelockLengthForOwnershipTransfer = 4 days;
+    uint public constant timelockLengthForFeeChanges = 8 hours;
+    
+
+    address public immutable manager;
+    address public immutable feeCollector;
+
+    mapping(address => address) public pendingOwners;
+    mapping(address => uint) public pendingAdminFees;
+    mapping(address => uint) public pendingDevFees;
+    mapping(address => uint) public pendingReinvestRewards;
+    mapping(address => address) public pendingTokenAddressesToRecover;
+    mapping(address => uint) public pendingTokenAmountsToRecover;
+    mapping(address => uint) public pendingAVAXToRecover;
+
+    event ProposeOwner(address indexed strategy, address indexed proposedValue, uint timelock);
+    event ProposeAdminFee(address indexed strategy, uint proposedValue, uint timelock);
+    event ProposeDevFee(address indexed strategy, uint proposedValue, uint timelock);
+    event ProposeReinvestReward(address indexed strategy, uint proposedValue, uint timelock);
+    event ProposeRecovery(address indexed strategy, address indexed proposedToken, uint proposedValue, uint timelock);
+
+    event SetOwner(address indexed strategy, address indexed newValue);
+    event SetAdminFee(address indexed strategy, uint newValue);
+    event SetDevFee(address indexed strategy, uint newValue);
+    event SetReinvestReward(address indexed strategy, uint newValue);
+    event SetMinTokensToReinvest(address indexed strategy, uint newValue);
+    event SetDepositsEnabled(address indexed strategy, bool newValue);
+    event Sweep(address indexed token, uint amount);
+    event Recover(address indexed strategy, address indexed token, uint amount);
+    event EmergencyWithdraw(address indexed strategy);
+    event SetAllowances(address indexed strategy);
+    event SetMaxTokensToDepositWithoutReinvest(address indexed strategy, uint newValue);
+    event AllowDepositor(address indexed strategy, address indexed depositor);
+    event RemoveDepositor(address indexed strategy, address indexed depositor);
+
+    enum Functions {
+        renounceOwnership,
+        transferOwnership,
+        emergencyWithdraw,
+        updateMinTokensToReinvest,
+        updateAdminFee,
+        updateDevFee,
+        updateReinvestReward,
+        recoverERC20,
+        recoverAVAX
+    }
+
+    mapping(address => mapping(Functions => uint)) public timelock;
+
+    constructor() {
+        manager = msg.sender;
+        feeCollector = msg.sender;
+        _setupRole(DEFAULT_ADMIN_ROLE, msg.sender);
+    }
+
+    // Modifiers
+
+    /**
+     * @notice Restrict to `manager`
+     * @dev To change manager, deploy new timelock and transfer strategy ownership
+     */
+    modifier onlyManager {
+        require(msg.sender == manager);
+        _;
+    }
+
+    /**
+     * @notice Restrict to `feeCollector`
+     * @dev To change feeCollector, deploy new timelock and transfer strategy ownership
+     */
+    modifier onlyFeeCollector {
+        require(msg.sender == feeCollector);
+        _;
+    }
+
+    /**
+     * @notice Set timelock when changing pending values
+     * @param _strategy address
+     * @param _fn Function enum value
+     * @param timelockLength in seconds
+     */
+    modifier setTimelock(address _strategy, Functions _fn, uint timelockLength) {
+        timelock[_strategy][_fn] = block.timestamp + timelockLength;
+        _;
+    }
+
+    /**
+     * @notice Enforce timelock for a given function
+     * @dev Ends execution by resetting timelock to avoid replay
+     * @param _strategy address
+     * @param _fn Function enum value
+     */
+    modifier enforceTimelock(address _strategy, Functions _fn) {
+        require(timelock[_strategy][_fn] != 0 && timelock[_strategy][_fn] <= block.timestamp, "YakTimelockManager::enforceTimelock");
+        _;
+        timelock[_strategy][_fn] = 0;
+    }
+
+    /**
+     * @notice Sweep tokens from the timelock to `feeCollector`
+     * @dev The timelock contract may receive assets from both revenue and asset recovery.
+     * @dev The sweep function is NOT timelocked, because recovered assets must go through separate timelock functions.
+     * @param tokenAddress address
+     * @param tokenAmount amount
+     */
+    function sweepTokens(address tokenAddress, uint tokenAmount) external onlysweepTokens_ADMIN {
+        require(tokenAmount > 0, "YakTimelockManager::sweepTokens, amount too low");
+        require(IERC20(tokenAddress).transfer(msg.sender, tokenAmount), "YakTimelockManager::sweepTokens, transfer failed");
+        emit Sweep(tokenAddress, tokenAmount);
+    }
+
+    /**
+     * @notice Sweep AVAX from the timelock to the `feeCollector` address
+     * @dev The timelock contract may receive assets from both revenue and asset recovery.
+     * @dev The sweep function is NOT timelocked, because recovered assets must go through separate timelock functions.
+     * @param amount amount
+     */
+    function sweepAVAX(uint amount) external onlysweepAVAX_ADMIN {
+        require(amount > 0, 'YakTimelockManager::sweepAVAX, amount too low');
+        msg.sender.transfer(amount);
+        emit Sweep(address(0), amount);
+    }
+
+    // Functions with timelocks
+
+    /**
+     * @notice Pass new value of `owner` through timelock
+     * @dev Restricted to `manager` to avoid griefing
+     * @dev Resets timelock duration through modifier
+     * @param _strategy address
+     * @param _pendingOwner new value
+     */
+    function proposeOwner(address _strategy, address _pendingOwner) external onlyproposeOwner_ADMIN 
+    setTimelock(_strategy, Functions.transferOwnership, timelockLengthForOwnershipTransfer) {
+        pendingOwners[_strategy] = _pendingOwner;
+        emit ProposeOwner(_strategy, _pendingOwner, timelock[_strategy][Functions.transferOwnership]);
+    }
+
+    /**
+     * @notice Set new value of `owner` and resets timelock
+     * @dev This can be called by anyone
+     * @param _strategy address
+     */
+    function setOwner(address _strategy) external 
+    enforceTimelock(_strategy, Functions.transferOwnership) {
+        IStrategy(_strategy).transferOwnership(pendingOwners[_strategy]);
+        emit SetOwner(_strategy, pendingOwners[_strategy]);
+        pendingOwners[_strategy] = address(0);
+    }
+
+    /**
+     * @notice Pass new value of `adminFee` through timelock
+     * @dev Restricted to `manager` to avoid griefing
+     * @dev Resets timelock duration through modifier
+     * @param _strategy address
+     * @param _pendingAdminFee new value
+     */
+    function proposeAdminFee(address _strategy, uint _pendingAdminFee) external onlyproposeAdminFee_ADMIN 
+    setTimelock(_strategy, Functions.updateAdminFee, timelockLengthForFeeChanges) {
+        pendingAdminFees[_strategy] = _pendingAdminFee;
+        emit ProposeAdminFee(_strategy, _pendingAdminFee, timelock[_strategy][Functions.updateAdminFee]);
+    }
+
+    /**
+     * @notice Set new value of `adminFee` and reset timelock
+     * @dev This can be called by anyone
+     * @param _strategy address
+     */
+    function setAdminFee(address _strategy) external 
+    enforceTimelock(_strategy, Functions.updateAdminFee) {
+        IStrategy(_strategy).updateAdminFee(pendingAdminFees[_strategy]);
+        emit SetAdminFee(_strategy, pendingAdminFees[_strategy]);
+        pendingAdminFees[_strategy] = 0;
+    }
+
+    /**
+     * @notice Pass new value of `devFee` through timelock
+     * @dev Restricted to `manager` to avoid griefing
+     * @dev Resets timelock duration through modifier
+     * @param _strategy address
+     * @param _pendingDevFee new value
+     */
+    function proposeDevFee(address _strategy, uint _pendingDevFee) external onlyproposeDevFee_ADMIN 
+    setTimelock(_strategy, Functions.updateDevFee, timelockLengthForFeeChanges) {
+        pendingDevFees[_strategy] = _pendingDevFee;
+        emit ProposeDevFee(_strategy, _pendingDevFee, timelock[_strategy][Functions.updateDevFee]);
+    }
+
+    /**
+     * @notice Set new value of `devFee` and reset timelock
+     * @dev This can be called by anyone
+     * @param _strategy address
+     */
+    function setDevFee(address _strategy) external 
+    enforceTimelock(_strategy, Functions.updateDevFee) {
+        IStrategy(_strategy).updateDevFee(pendingDevFees[_strategy]);
+        emit SetDevFee(_strategy, pendingDevFees[_strategy]);
+        pendingDevFees[_strategy] = 0;
+    }
+
+    /**
+     * @notice Pass new value of `reinvestReward` through timelock
+     * @dev Restricted to `manager` to avoid griefing
+     * @dev Resets timelock duration through modifier
+     * @param _strategy address
+     * @param _pendingReinvestReward new value
+     */
+    function proposeReinvestReward(address _strategy, uint _pendingReinvestReward) external onlyproposeReinvestReward_ADMIN 
+    setTimelock(_strategy, Functions.updateReinvestReward, timelockLengthForFeeChanges) {
+        pendingReinvestRewards[_strategy] = _pendingReinvestReward;
+        emit ProposeReinvestReward(_strategy, _pendingReinvestReward, timelock[_strategy][Functions.updateReinvestReward]);
+    }
+
+    /**
+     * @notice Set new value of `reinvestReward` and reset timelock
+     * @dev This can be called by anyone
+     * @param _strategy address
+     */
+    function setReinvestReward(address _strategy) external 
+    enforceTimelock(_strategy, Functions.updateReinvestReward) {
+        IStrategy(_strategy).updateReinvestReward(pendingReinvestRewards[_strategy]);
+        emit SetReinvestReward(_strategy, pendingReinvestRewards[_strategy]);
+        pendingReinvestRewards[_strategy] = 0;
+    }
+
+    /**
+     * @notice Pass values for `recoverERC20` through timelock
+     * @dev Restricted to `manager` to avoid griefing
+     * @dev Resets timelock duration through modifier
+     * @param _strategy address
+     * @param _pendingTokenAddressToRecover address
+     * @param _pendingTokenAmountToRecover amount
+     */
+    function proposeRecoverERC20(address _strategy, address _pendingTokenAddressToRecover, uint _pendingTokenAmountToRecover) external onlyproposeRecoverERC20_ADMIN 
+    setTimelock(_strategy, Functions.recoverERC20, timelockLengthForAssetRecovery) {
+        pendingTokenAddressesToRecover[_strategy] = _pendingTokenAddressToRecover;
+        pendingTokenAmountsToRecover[_strategy] = _pendingTokenAmountToRecover;
+        emit ProposeRecovery(_strategy, _pendingTokenAddressToRecover, _pendingTokenAmountToRecover, timelock[_strategy][Functions.recoverERC20]);
+    }
+
+    /**
+     * @notice Call `recoverERC20` and reset timelock
+     * @dev This can be called by anyone
+     * @dev Recoverd funds are collected to this timelock and may be swept
+     * @param _strategy address
+     */
+    function setRecoverERC20(address _strategy) external 
+    enforceTimelock(_strategy, Functions.recoverERC20) {
+        IStrategy(_strategy).recoverERC20(pendingTokenAddressesToRecover[_strategy], pendingTokenAmountsToRecover[_strategy]);
+        emit Recover(_strategy, pendingTokenAddressesToRecover[_strategy], pendingTokenAmountsToRecover[_strategy]);
+        pendingTokenAddressesToRecover[_strategy] = address(0);
+        pendingTokenAmountsToRecover[_strategy] = 0;
+    }
+
+    /**
+     * @notice Pass values for `recoverAVAX` through timelock
+     * @dev Restricted to `manager` to avoid griefing
+     * @dev Resets timelock duration through modifier
+     * @param _strategy address
+     * @param _pendingAVAXToRecover amount
+     */
+    function proposeRecoverAVAX(address _strategy, uint _pendingAVAXToRecover) external onlyproposeRecoverAVAX_ADMIN 
+    setTimelock(_strategy, Functions.recoverAVAX, timelockLengthForAssetRecovery) {
+        pendingAVAXToRecover[_strategy] = _pendingAVAXToRecover;
+        emit ProposeRecovery(_strategy, address(0), _pendingAVAXToRecover, timelock[_strategy][Functions.recoverAVAX]);
+    }
+
+    /**
+     * @notice Call `recoverAVAX` and reset timelock
+     * @dev This can be called by anyone
+     * @dev Recoverd funds are collected to this timelock and may be swept
+     * @param _strategy address
+     */
+    function setRecoverAVAX(address _strategy) external 
+    enforceTimelock(_strategy, Functions.recoverAVAX) {
+        IStrategy(_strategy).recoverAVAX(pendingAVAXToRecover[_strategy]);
+        emit Recover(_strategy, address(0), pendingAVAXToRecover[_strategy]);
+        pendingAVAXToRecover[_strategy] = 0;
+    }
+
+    // Functions without timelocks
+
+    /**
+     * @notice Set new value of `minTokensToReinvest`
+     * @dev Restricted to `manager` to avoid griefing
+     * @param _strategy address
+     * @param newValue min tokens
+     */
+    function setMinTokensToReinvest(address _strategy, uint newValue) external onlysetMinTokensToReinvest_ADMIN {
+        IStrategy(_strategy).updateMinTokensToReinvest(newValue);
+        emit SetMinTokensToReinvest(_strategy, newValue);
+    }
+
+    /**
+     * @notice Set new value of `maxTokensToDepositWithoutReinvest`
+     * @dev Restricted to `manager` to avoid griefing
+     * @param _strategy address
+     * @param newValue max tokens
+     */
+    function setMaxTokensToDepositWithoutReinvest(address _strategy, uint newValue) external onlysetMaxTokensToDepositWithoutReinvest_ADMIN {
+        IStrategy(_strategy).updateMaxTokensToDepositWithoutReinvest(newValue);
+        emit SetMaxTokensToDepositWithoutReinvest(_strategy, newValue);
+    }
+
+    /**
+     * @notice Enable/disable deposits (After YakStrategy)
+     * @param _strategy address
+     * @param newValue bool
+     */
+    function setDepositsEnabled(address _strategy, bool newValue) external onlysetDepositsEnabled_ADMIN {
+        IStrategy(_strategy).updateDepositsEnabled(newValue);
+        emit SetDepositsEnabled(_strategy, newValue);
+    }
+
+    /**
+     * @notice Rescues deployed assets to the strategy contract (Before YakStrategy)
+     * @dev Restricted to `manager` to avoid griefing
+     * @param _strategy address
+     */
+    function emergencyWithdraw(address _strategy) external onlyemergencyWithdraw_ADMIN {
+        IStrategy(_strategy).emergencyWithdraw();
+        emit EmergencyWithdraw(_strategy);
+    }
+
+    /**
+     * @notice Rescues deployed assets to the strategy contract (After YakStrategy)
+     * @dev Restricted to `manager` to avoid griefing
+     * @param _strategy address
+     * @param minReturnAmountAccepted amount
+     * @param disableDeposits bool
+     */
+    function rescueDeployedFunds(address _strategy, uint minReturnAmountAccepted, bool disableDeposits) external onlyrescueDeployedFunds_ADMIN {
+        IStrategy(_strategy).rescueDeployedFunds(minReturnAmountAccepted, disableDeposits);
+        emit EmergencyWithdraw(_strategy);
+    }
+
+    /**
+     * @notice Sets token approvals
+     * @dev Restricted to `manager` to avoid griefing
+     * @param _strategy address
+     */
+    function setAllowances(address _strategy) external onlysetAllowances_ADMIN {
+        IStrategy(_strategy).setAllowances();
+        emit SetAllowances(_strategy);
+    }
+
+    /**
+     * @notice Add to list of allowed depositors
+     * @param _strategy address
+     * @param depositor address
+     */
+    function allowDepositor(address _strategy, address depositor) external onlyallowDepositor_ADMIN {
+        IStrategy(_strategy).allowDepositor(depositor);
+        emit AllowDepositor(_strategy, depositor);
+    }
+
+    /**
+     * @notice Remove from list of allowed depositors
+     * @param _strategy address
+     * @param depositor address
+     */
+    function removeDepositor(address _strategy, address depositor) external onlyremoveDepositor_ADMIN {
+        IStrategy(_strategy).removeDepositor(depositor);
+        emit RemoveDepositor(_strategy, depositor);
+    }
+}


### PR DESCRIPTION
Initially every function admin role is assigned by default to the Deployer.
Deployer can later call "_setRoleAdmin" to grant admin previlege to an account for a method. admin role can only be assigned to one., once admin calls the above method., it transfers ownership. 
Deployer can call "grantRole"/ "revokeRole" for a method for an account.