### PR TITLE
Banker joe strategies remove verifying msg.sender

### DIFF
--- a/contracts/strategies/JoeLendingStrategyAvaxV1.sol
+++ b/contracts/strategies/JoeLendingStrategyAvaxV1.sol
@@ -69,12 +69,9 @@ contract JoeLendingStrategyAvaxV1 is YakStrategyV2Payable, ReentrancyGuard {
     }
 
     function totalDeposits() public view override returns (uint256) {
-        (
-            ,
-            uint256 internalBalance,
-            uint256 borrow,
-            uint256 exchangeRate
-        ) = tokenDelegator.getAccountSnapshot(address(this));
+        (, uint256 internalBalance, uint256 borrow, uint256 exchangeRate) = tokenDelegator.getAccountSnapshot(
+            address(this)
+        );
         return internalBalance.mul(exchangeRate).div(1e18).sub(borrow);
     }
 
@@ -95,10 +92,7 @@ contract JoeLendingStrategyAvaxV1 is YakStrategyV2Payable, ReentrancyGuard {
         leverageBips = _leverageBips;
     }
 
-    function updateLeverage(uint256 _leverageLevel, uint256 _leverageBips)
-        external
-        onlyDev
-    {
+    function updateLeverage(uint256 _leverageLevel, uint256 _leverageBips) external onlyDev {
         _updateLeverage(_leverageLevel, _leverageBips);
         uint256 balance = _totalDepositsFresh();
         _unrollDebt(balance);
@@ -113,10 +107,7 @@ contract JoeLendingStrategyAvaxV1 is YakStrategyV2Payable, ReentrancyGuard {
      * @dev Assigns values to swapPairToken0 and swapPairToken1
      */
     function assignSwapPairSafely(address _swapPairToken0) private {
-        require(
-            _swapPairToken0 > address(0),
-            "Swap pair 0 is necessary but not supplied"
-        );
+        require(_swapPairToken0 > address(0), "Swap pair 0 is necessary but not supplied");
         require(
             address(rewardToken0) == IPair(address(_swapPairToken0)).token0() ||
                 address(rewardToken0) == IPair(address(_swapPairToken0)).token1(),
@@ -166,9 +157,7 @@ contract JoeLendingStrategyAvaxV1 is YakStrategyV2Payable, ReentrancyGuard {
         require(DEPOSITS_ENABLED == true, "JoeLendingStrategyAvaxV1::_deposit");
         if (MAX_TOKENS_TO_DEPOSIT_WITHOUT_REINVEST > 0) {
             (uint256 joeRewards, uint256 avaxBalance, uint256 amountToReinvest) = _checkRewards();
-            if (
-                amountToReinvest > MAX_TOKENS_TO_DEPOSIT_WITHOUT_REINVEST
-            ) {
+            if (amountToReinvest > MAX_TOKENS_TO_DEPOSIT_WITHOUT_REINVEST) {
                 _reinvest(joeRewards, avaxBalance, amountToReinvest);
             }
         }
@@ -185,10 +174,7 @@ contract JoeLendingStrategyAvaxV1 is YakStrategyV2Payable, ReentrancyGuard {
 
     function withdraw(uint256 amount) external override {
         uint256 depositTokenAmount = _totalDepositsFresh().mul(amount).div(totalSupply);
-        require(
-            depositTokenAmount > minMinting,
-            "JoeLendingStrategyAvaxV1:: below minimum withdraw"
-        );
+        require(depositTokenAmount > minMinting, "JoeLendingStrategyAvaxV1:: below minimum withdraw");
         _burn(msg.sender, amount);
         _withdrawDepositTokens(depositTokenAmount);
         (bool success, ) = msg.sender.call{value: depositTokenAmount}("");
@@ -199,10 +185,7 @@ contract JoeLendingStrategyAvaxV1 is YakStrategyV2Payable, ReentrancyGuard {
 
     function _withdrawDepositTokens(uint256 amount) private {
         _unrollDebt(amount);
-        require(
-            tokenDelegator.redeemUnderlyingNative(amount) == 0,
-            "JoeLendingStrategyAvaxV1::redeem failed"
-        );
+        require(tokenDelegator.redeemUnderlyingNative(amount) == 0, "JoeLendingStrategyAvaxV1::redeem failed");
         uint256 balance = tokenDelegator.balanceOfUnderlying(address(this));
         uint256 borrow = tokenDelegator.borrowBalanceCurrent(address(this));
         if (balance > 0) {
@@ -212,16 +195,12 @@ contract JoeLendingStrategyAvaxV1 is YakStrategyV2Payable, ReentrancyGuard {
 
     function reinvest() external override onlyEOA nonReentrant {
         (uint256 joeRewards, uint256 avaxBalance, uint256 amountToReinvest) = _checkRewards();
-        require(
-            amountToReinvest >= MIN_TOKENS_TO_REINVEST,
-            "JoeLendingStrategyAvaxV1::reinvest"
-        );
+        require(amountToReinvest >= MIN_TOKENS_TO_REINVEST, "JoeLendingStrategyAvaxV1::reinvest");
         _reinvest(joeRewards, avaxBalance, amountToReinvest);
         claimAVAXRewards();
     }
 
-    receive() external payable {
-    }
+    receive() external payable {}
 
     /**
      * @notice Reinvest rewards from staking contract to deposit tokens
@@ -230,7 +209,11 @@ contract JoeLendingStrategyAvaxV1 is YakStrategyV2Payable, ReentrancyGuard {
      * @param avaxBalance amount of AVAX to reinvest
      * @param amount total amount of reward tokens to reinvest
      */
-    function _reinvest(uint256 joeRewards, uint256 avaxBalance, uint256 amount) private {
+    function _reinvest(
+        uint256 joeRewards,
+        uint256 avaxBalance,
+        uint256 amount
+    ) private {
         if (joeRewards > 0) {
             rewardController.claimReward(0, address(this));
             uint256 joeAsWavax = DexLibrary.swap(
@@ -242,9 +225,7 @@ contract JoeLendingStrategyAvaxV1 is YakStrategyV2Payable, ReentrancyGuard {
             WAVAX.withdraw(joeAsWavax);
         }
 
-        uint256 fees = amount.mul(
-            DEV_FEE_BIPS.add(ADMIN_FEE_BIPS).add(REINVEST_REWARD_BIPS)
-        ).div(BIPS_DIVISOR);
+        uint256 fees = amount.mul(DEV_FEE_BIPS.add(ADMIN_FEE_BIPS).add(REINVEST_REWARD_BIPS)).div(BIPS_DIVISOR);
         WAVAX.deposit{value: fees}();
 
         uint256 devFee = amount.mul(DEV_FEE_BIPS).div(BIPS_DIVISOR);
@@ -284,18 +265,11 @@ contract JoeLendingStrategyAvaxV1 is YakStrategyV2Payable, ReentrancyGuard {
     function _rollupDebt(uint256 principal, uint256 borrowed) internal {
         (uint256 borrowLimit, uint256 borrowBips) = _getBorrowLimit();
         uint256 supplied = principal;
-        uint256 lendTarget = principal.sub(borrowed).mul(leverageLevel).div(
-            leverageBips
-        );
+        uint256 lendTarget = principal.sub(borrowed).mul(leverageLevel).div(leverageBips);
         uint256 totalBorrowed = borrowed;
 
         while (supplied < lendTarget) {
-            uint256 toBorrowAmount = _getBorrowable(
-                supplied,
-                totalBorrowed,
-                borrowLimit,
-                borrowBips
-            );
+            uint256 toBorrowAmount = _getBorrowable(supplied, totalBorrowed, borrowLimit, borrowBips);
             if (supplied.add(toBorrowAmount) > lendTarget) {
                 toBorrowAmount = lendTarget.sub(supplied);
             }
@@ -303,10 +277,7 @@ contract JoeLendingStrategyAvaxV1 is YakStrategyV2Payable, ReentrancyGuard {
             if (toBorrowAmount < minMinting) {
                 break;
             }
-            require(
-                tokenDelegator.borrowNative(toBorrowAmount) == 0,
-                "JoeLendingStrategyAvaxV1::borrowing failed"
-            );
+            require(tokenDelegator.borrowNative(toBorrowAmount) == 0, "JoeLendingStrategyAvaxV1::borrowing failed");
             require(
                 tokenDelegator.mintNative{value: toBorrowAmount}() == 0,
                 "JoeLendingStrategyAvaxV1::lending failed"
@@ -334,21 +305,13 @@ contract JoeLendingStrategyAvaxV1 is YakStrategyV2Payable, ReentrancyGuard {
         uint256 borrowed = tokenDelegator.borrowBalanceCurrent(address(this));
         uint256 balance = tokenDelegator.balanceOfUnderlying(address(this));
         (uint256 borrowLimit, uint256 borrowBips) = _getBorrowLimit();
-        uint256 targetBorrow = balance
-            .sub(borrowed)
-            .sub(amountToFreeUp)
-            .mul(leverageLevel)
-            .div(leverageBips)
-            .sub(balance.sub(borrowed).sub(amountToFreeUp));
+        uint256 targetBorrow = balance.sub(borrowed).sub(amountToFreeUp).mul(leverageLevel).div(leverageBips).sub(
+            balance.sub(borrowed).sub(amountToFreeUp)
+        );
         uint256 toRepay = borrowed.sub(targetBorrow);
 
         while (toRepay > 0) {
-            uint256 unrollAmount = _getBorrowable(
-                balance,
-                borrowed,
-                borrowLimit,
-                borrowBips
-            );
+            uint256 unrollAmount = _getBorrowable(balance, borrowed, borrowLimit, borrowBips);
             if (unrollAmount > borrowed) {
                 unrollAmount = borrowed;
             }
@@ -371,10 +334,7 @@ contract JoeLendingStrategyAvaxV1 is YakStrategyV2Payable, ReentrancyGuard {
 
     function _stakeDepositTokens(uint256 amount) private {
         require(amount > 0, "JoeLendingStrategyAvaxV1::_stakeDepositTokens");
-        require(
-            tokenDelegator.mintNative{value: amount}() == 0,
-            "JoeLendingStrategyAvaxV1::Deposit failed"
-        );
+        require(tokenDelegator.mintNative{value: amount}() == 0, "JoeLendingStrategyAvaxV1::Deposit failed");
         uint256 borrowed = tokenDelegator.borrowBalanceCurrent(address(this));
         uint256 principal = tokenDelegator.balanceOfUnderlying(address(this));
         _rollupDebt(principal, borrowed);
@@ -392,10 +352,7 @@ contract JoeLendingStrategyAvaxV1 is YakStrategyV2Payable, ReentrancyGuard {
         address to,
         uint256 value
     ) private {
-        require(
-            IERC20(token).transfer(to, value),
-            "JoeLendingStrategyAvaxV1::TRANSFER_FROM_FAILED"
-        );
+        require(IERC20(token).transfer(to, value), "JoeLendingStrategyAvaxV1::TRANSFER_FROM_FAILED");
     }
 
     /// @notice Returns rewards that can be reinvested
@@ -426,41 +383,21 @@ contract JoeLendingStrategyAvaxV1 is YakStrategyV2Payable, ReentrancyGuard {
      * @return amount that can be reinvested
      */
     function checkReward() public view override returns (uint256) {
-        (,, uint256 totalAmount) = _checkRewards();
+        (, , uint256 totalAmount) = _checkRewards();
         return totalAmount;
     }
 
-    function _getReward(uint8 tokenIndex, address account)
-        internal
-        view
-        returns (uint256)
-    {
-        IJoeRewardDistributor rewardDistributor = IJoeRewardDistributor(
-            rewardController.rewardDistributor()
-        );
-        (uint224 supplyIndex, ) = rewardDistributor.rewardSupplyState(
-            tokenIndex,
-            account
-        );
-        uint256 supplierIndex = rewardDistributor.rewardSupplierIndex(
-            tokenIndex,
-            address(tokenDelegator),
-            account
-        );
+    function _getReward(uint8 tokenIndex, address account) internal view returns (uint256) {
+        IJoeRewardDistributor rewardDistributor = IJoeRewardDistributor(rewardController.rewardDistributor());
+        (uint224 supplyIndex, ) = rewardDistributor.rewardSupplyState(tokenIndex, account);
+        uint256 supplierIndex = rewardDistributor.rewardSupplierIndex(tokenIndex, address(tokenDelegator), account);
 
         uint256 supplyIndexDelta = 0;
         if (supplyIndex > supplierIndex) {
             supplyIndexDelta = supplyIndex - supplierIndex;
         }
-        (uint224 borrowIndex, ) = rewardDistributor.rewardBorrowState(
-            tokenIndex,
-            account
-        );
-        uint256 borrowerIndex = rewardDistributor.rewardBorrowerIndex(
-            tokenIndex,
-            address(tokenDelegator),
-            account
-        );
+        (uint224 borrowIndex, ) = rewardDistributor.rewardBorrowState(tokenIndex, account);
+        uint256 borrowerIndex = rewardDistributor.rewardBorrowerIndex(tokenIndex, address(tokenDelegator), account);
         uint256 borrowIndexDelta = 0;
         if (borrowIndex > borrowerIndex) {
             borrowIndexDelta = borrowIndex - borrowerIndex;
@@ -474,12 +411,9 @@ contract JoeLendingStrategyAvaxV1 is YakStrategyV2Payable, ReentrancyGuard {
     }
 
     function getActualLeverage() public view returns (uint256) {
-        (
-            ,
-            uint256 internalBalance,
-            uint256 borrow,
-            uint256 exchangeRate
-        ) = tokenDelegator.getAccountSnapshot(address(this));
+        (, uint256 internalBalance, uint256 borrow, uint256 exchangeRate) = tokenDelegator.getAccountSnapshot(
+            address(this)
+        );
         uint256 balance = internalBalance.mul(exchangeRate).div(1e18);
         return balance.mul(1e18).div(balance.sub(borrow));
     }
@@ -488,11 +422,7 @@ contract JoeLendingStrategyAvaxV1 is YakStrategyV2Payable, ReentrancyGuard {
         return totalDeposits();
     }
 
-    function rescueDeployedFunds(uint256 minReturnAmountAccepted, bool disableDeposits)
-        external
-        override
-        onlyOwner
-    {
+    function rescueDeployedFunds(uint256 minReturnAmountAccepted, bool disableDeposits) external override onlyOwner {
         uint256 balanceBefore = address(this).balance;
         uint256 balance = _totalDepositsFresh();
         _unrollDebt(balance);

--- a/contracts/strategies/JoeLendingStrategyAvaxV1.sol
+++ b/contracts/strategies/JoeLendingStrategyAvaxV1.sol
@@ -221,12 +221,6 @@ contract JoeLendingStrategyAvaxV1 is YakStrategyV2Payable, ReentrancyGuard {
     }
 
     receive() external payable {
-        require(
-            msg.sender == address(rewardController) ||
-                msg.sender == address(WAVAX) ||
-                msg.sender == address(tokenDelegator),
-            "JoeLendingStrategyAvaxV1::payments not allowed"
-        );
     }
 
     /**

--- a/contracts/strategies/JoeLendingStrategyV1.sol
+++ b/contracts/strategies/JoeLendingStrategyV1.sol
@@ -190,7 +190,7 @@ contract JoeLendingStrategyV1 is YakStrategyV2 {
             }
         }
         require(
-            depositToken.transferFrom(msg.sender, address(this), amount),
+            depositToken.transferFrom(account, address(this), amount),
             "JoeLendingStrategyV1::transfer failed"
         );
         uint256 shareTokenAmount = amount;
@@ -238,10 +238,6 @@ contract JoeLendingStrategyV1 is YakStrategyV2 {
     }
 
     receive() external payable {
-        require(
-            msg.sender == address(rewardController),
-            "JoeLendingStrategyV1::payments not allowed"
-        );
     }
 
     /**


### PR DESCRIPTION
1. avax are transferred from the reward distributor, not joetroller.
2. since it is using transfer, don't verify msg.sender.

Joetroller#claimReward
https://github.com/traderjoe-xyz/joe-lending/blob/83dd51339cf82563eb7f7e1060fc9ed6ccbe9b80/contracts/Joetroller.sol#L1378

RewardDistributor#grantRewardInternal
https://github.com/traderjoe-xyz/joe-lending/blob/83dd51339cf82563eb7f7e1060fc9ed6ccbe9b80/contracts/RewardDistributor.sol#L380